### PR TITLE
Speed up NSP extraction and add Required Firmware info for NSP files

### DIFF
--- a/Switch Backup Manager/Form1.Designer.cs
+++ b/Switch Backup Manager/Form1.Designer.cs
@@ -50,6 +50,8 @@
             this.olvColumnDeveloperLocal = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
             this.olvColumnGameRevisionLocal = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
             this.olvColumnMasterKeyLocal = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
+            this.olvColumnFirmwareLocal = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
+            this.olvColumnSDKVersionLocal = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
             this.contextMenuLocalList = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.showInExplorerToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem20 = new System.Windows.Forms.ToolStripSeparator();
@@ -141,6 +143,8 @@
             this.olvColumnDeveloperSD = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
             this.olvColumnGameRevisionSD = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
             this.olvColumnMasterKeySD = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
+            this.olvColumnFirmwareSD = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
+            this.olvColumnSDKVersionSD = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
             this.contextMenuStripSDCard = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.showInExplorerToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem21 = new System.Windows.Forms.ToolStripSeparator();
@@ -293,6 +297,8 @@
             this.olvColumnGameRevisionEShop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
             this.olvColumnMasterKeyRevisionEShop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
             this.olvColumnDistributionType = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
+            this.olvColumnFirmwareEShop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
+            this.olvColumnSDKVersionEShop = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
             this.contextMenuStripEShop = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.toolStripMenuItemEShopShowInExplorer = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItemEShopUpdateInfo = new System.Windows.Forms.ToolStripMenuItem();
@@ -344,6 +350,8 @@
             this.toolStripMenuItemCopyFilesToFolderEShop = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItemMoveFilesToFolderEShop = new System.Windows.Forms.ToolStripMenuItem();
             this.tabPage5 = new System.Windows.Forms.TabPage();
+            this.panel6 = new System.Windows.Forms.Panel();
+            this.richTextBoxLog = new System.Windows.Forms.RichTextBox();
             this.panel7 = new System.Windows.Forms.Panel();
             this.btnClearLogFile = new System.Windows.Forms.Button();
             this.statusStrip1 = new System.Windows.Forms.StatusStrip();
@@ -368,8 +376,6 @@
             this.backgroundWorkerLoadSDCardFiles = new System.ComponentModel.BackgroundWorker();
             this.backgroundWorkerScanNewFiles = new System.ComponentModel.BackgroundWorker();
             this.backgroundWorkerUpdateFiles = new System.ComponentModel.BackgroundWorker();
-            this.panel6 = new System.Windows.Forms.Panel();
-            this.richTextBoxLog = new System.Windows.Forms.RichTextBox();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
@@ -401,10 +407,10 @@
             this.contextMenuStripEShop.SuspendLayout();
             this.menuEShop.SuspendLayout();
             this.tabPage5.SuspendLayout();
+            this.panel6.SuspendLayout();
             this.panel7.SuspendLayout();
             this.statusStrip1.SuspendLayout();
             this.menuStrip1.SuspendLayout();
-            this.panel6.SuspendLayout();
             this.SuspendLayout();
             // 
             // splitContainer1
@@ -521,6 +527,8 @@
             this.OLVLocalFiles.AllColumns.Add(this.olvColumnDeveloperLocal);
             this.OLVLocalFiles.AllColumns.Add(this.olvColumnGameRevisionLocal);
             this.OLVLocalFiles.AllColumns.Add(this.olvColumnMasterKeyLocal);
+            this.OLVLocalFiles.AllColumns.Add(this.olvColumnFirmwareLocal);
+            this.OLVLocalFiles.AllColumns.Add(this.olvColumnSDKVersionLocal);
             this.OLVLocalFiles.CellEditUseWholeCell = false;
             this.OLVLocalFiles.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.olvColumnTitleIDLocal,
@@ -534,7 +542,9 @@
             this.olvColumnFilePathLocal,
             this.olvColumnDeveloperLocal,
             this.olvColumnGameRevisionLocal,
-            this.olvColumnMasterKeyLocal});
+            this.olvColumnMasterKeyLocal,
+            this.olvColumnFirmwareLocal,
+            this.olvColumnSDKVersionLocal});
             this.OLVLocalFiles.ContextMenuStrip = this.contextMenuLocalList;
             this.OLVLocalFiles.Cursor = System.Windows.Forms.Cursors.Default;
             this.OLVLocalFiles.Dock = System.Windows.Forms.DockStyle.Fill;
@@ -565,7 +575,7 @@
             this.olvColumnGameNameLocal.AspectName = "GameName";
             this.olvColumnGameNameLocal.Text = "Game title";
             this.olvColumnGameNameLocal.UseInitialLetterForGroup = true;
-            this.olvColumnGameNameLocal.Width = 344;
+            this.olvColumnGameNameLocal.Width = 260;
             // 
             // olvColumnROMSizeLocal
             // 
@@ -600,7 +610,7 @@
             // 
             this.olvColumnLanguagesLocal.AspectName = "Languages";
             this.olvColumnLanguagesLocal.Text = "Languages";
-            this.olvColumnLanguagesLocal.Width = 154;
+            this.olvColumnLanguagesLocal.Width = 84;
             // 
             // olvColumnCardTypeLocal
             // 
@@ -614,7 +624,7 @@
             this.olvColumnFilePathLocal.AspectName = "FilePath";
             this.olvColumnFilePathLocal.Text = "Filename";
             this.olvColumnFilePathLocal.UseInitialLetterForGroup = true;
-            this.olvColumnFilePathLocal.Width = 291;
+            this.olvColumnFilePathLocal.Width = 260;
             // 
             // olvColumnDeveloperLocal
             // 
@@ -634,6 +644,18 @@
             this.olvColumnMasterKeyLocal.AspectName = "MasterKeyRevision";
             this.olvColumnMasterKeyLocal.Text = "Masterkey revision";
             this.olvColumnMasterKeyLocal.Width = 135;
+            // 
+            // olvColumnFirmwareLocal
+            // 
+            this.olvColumnFirmwareLocal.AspectName = "Firmware";
+            this.olvColumnFirmwareLocal.Text = "Firmware";
+            this.olvColumnFirmwareLocal.Width = 100;
+            // 
+            // olvColumnSDKVersionLocal
+            // 
+            this.olvColumnSDKVersionLocal.AspectName = "SDKVersion";
+            this.olvColumnSDKVersionLocal.Text = "SDK Version";
+            this.olvColumnSDKVersionLocal.Width = 100;
             // 
             // contextMenuLocalList
             // 
@@ -1229,7 +1251,7 @@
             this.tabPage2.Location = new System.Drawing.Point(4, 22);
             this.tabPage2.Name = "tabPage2";
             this.tabPage2.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage2.Size = new System.Drawing.Size(1574, 591);
+            this.tabPage2.Size = new System.Drawing.Size(1576, 593);
             this.tabPage2.TabIndex = 1;
             this.tabPage2.Text = "SD card";
             this.tabPage2.UseVisualStyleBackColor = true;
@@ -1285,6 +1307,8 @@
             this.OLV_SDCard.AllColumns.Add(this.olvColumnDeveloperSD);
             this.OLV_SDCard.AllColumns.Add(this.olvColumnGameRevisionSD);
             this.OLV_SDCard.AllColumns.Add(this.olvColumnMasterKeySD);
+            this.OLV_SDCard.AllColumns.Add(this.olvColumnFirmwareSD);
+            this.OLV_SDCard.AllColumns.Add(this.olvColumnSDKVersionSD);
             this.OLV_SDCard.CellEditUseWholeCell = false;
             this.OLV_SDCard.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.olvColumnTitleIDSD,
@@ -1298,7 +1322,9 @@
             this.olvColumnFilePathSD,
             this.olvColumnDeveloperSD,
             this.olvColumnGameRevisionSD,
-            this.olvColumnMasterKeySD});
+            this.olvColumnMasterKeySD,
+            this.olvColumnFirmwareSD,
+            this.olvColumnSDKVersionSD});
             this.OLV_SDCard.ContextMenuStrip = this.contextMenuStripSDCard;
             this.OLV_SDCard.Cursor = System.Windows.Forms.Cursors.Default;
             this.OLV_SDCard.Dock = System.Windows.Forms.DockStyle.Fill;
@@ -1307,7 +1333,7 @@
             this.OLV_SDCard.Location = new System.Drawing.Point(3, 55);
             this.OLV_SDCard.Name = "OLV_SDCard";
             this.OLV_SDCard.ShowGroups = false;
-            this.OLV_SDCard.Size = new System.Drawing.Size(1568, 533);
+            this.OLV_SDCard.Size = new System.Drawing.Size(1570, 535);
             this.OLV_SDCard.TabIndex = 6;
             this.OLV_SDCard.UseCellFormatEvents = true;
             this.OLV_SDCard.UseCompatibleStateImageBehavior = false;
@@ -1328,7 +1354,7 @@
             this.olvColumnGameNameSD.AspectName = "GameName";
             this.olvColumnGameNameSD.Text = "Game title";
             this.olvColumnGameNameSD.UseInitialLetterForGroup = true;
-            this.olvColumnGameNameSD.Width = 414;
+            this.olvColumnGameNameSD.Width = 260;
             // 
             // olvColumnROMSizeSD
             // 
@@ -1377,7 +1403,7 @@
             this.olvColumnFilePathSD.AspectName = "FilePath";
             this.olvColumnFilePathSD.Text = "Filename";
             this.olvColumnFilePathSD.UseInitialLetterForGroup = true;
-            this.olvColumnFilePathSD.Width = 291;
+            this.olvColumnFilePathSD.Width = 260;
             // 
             // olvColumnDeveloperSD
             // 
@@ -1396,6 +1422,18 @@
             this.olvColumnMasterKeySD.AspectName = "MasterKeyRevision";
             this.olvColumnMasterKeySD.Text = "Masterkey revision";
             this.olvColumnMasterKeySD.Width = 142;
+            // 
+            // olvColumnFirmwareSD
+            // 
+            this.olvColumnFirmwareSD.AspectName = "Firmware";
+            this.olvColumnFirmwareSD.Text = "Firmware";
+            this.olvColumnFirmwareSD.Width = 100;
+            // 
+            // olvColumnSDKVersionSD
+            // 
+            this.olvColumnSDKVersionSD.AspectName = "SDKVersion";
+            this.olvColumnSDKVersionSD.Text = "SDK Version";
+            this.olvColumnSDKVersionSD.Width = 100;
             // 
             // contextMenuStripSDCard
             // 
@@ -1478,7 +1516,7 @@
             this.panel5.Dock = System.Windows.Forms.DockStyle.Top;
             this.panel5.Location = new System.Drawing.Point(3, 27);
             this.panel5.Name = "panel5";
-            this.panel5.Size = new System.Drawing.Size(1568, 28);
+            this.panel5.Size = new System.Drawing.Size(1570, 28);
             this.panel5.TabIndex = 5;
             // 
             // lblSpaceAvailabeOnSD
@@ -1524,7 +1562,7 @@
             this.toolStripMenuItem39});
             this.menuSDFiles.Location = new System.Drawing.Point(3, 3);
             this.menuSDFiles.Name = "menuSDFiles";
-            this.menuSDFiles.Size = new System.Drawing.Size(1568, 24);
+            this.menuSDFiles.Size = new System.Drawing.Size(1570, 24);
             this.menuSDFiles.TabIndex = 4;
             // 
             // toolStripMenuItem4
@@ -1922,7 +1960,7 @@
             this.tabPage3.Location = new System.Drawing.Point(4, 22);
             this.tabPage3.Name = "tabPage3";
             this.tabPage3.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage3.Size = new System.Drawing.Size(1574, 591);
+            this.tabPage3.Size = new System.Drawing.Size(1576, 593);
             this.tabPage3.TabIndex = 2;
             this.tabPage3.Text = "Scene releases";
             this.tabPage3.UseVisualStyleBackColor = true;
@@ -1938,7 +1976,7 @@
             this.panel4.Dock = System.Windows.Forms.DockStyle.Fill;
             this.panel4.Location = new System.Drawing.Point(3, 3);
             this.panel4.Name = "panel4";
-            this.panel4.Size = new System.Drawing.Size(1568, 585);
+            this.panel4.Size = new System.Drawing.Size(1570, 587);
             this.panel4.TabIndex = 0;
             // 
             // btnClearFilterScene
@@ -2012,7 +2050,7 @@
             this.OLVSceneList.Location = new System.Drawing.Point(0, 24);
             this.OLVSceneList.Name = "OLVSceneList";
             this.OLVSceneList.ShowGroups = false;
-            this.OLVSceneList.Size = new System.Drawing.Size(1568, 561);
+            this.OLVSceneList.Size = new System.Drawing.Size(1570, 563);
             this.OLVSceneList.TabIndex = 6;
             this.OLVSceneList.UseCellFormatEvents = true;
             this.OLVSceneList.UseCompatibleStateImageBehavior = false;
@@ -2120,7 +2158,7 @@
             this.toolStripMenuItem85});
             this.menuStrip3.Location = new System.Drawing.Point(0, 0);
             this.menuStrip3.Name = "menuStrip3";
-            this.menuStrip3.Size = new System.Drawing.Size(1568, 24);
+            this.menuStrip3.Size = new System.Drawing.Size(1570, 24);
             this.menuStrip3.TabIndex = 5;
             this.menuStrip3.Text = "menuStrip3";
             // 
@@ -2507,9 +2545,9 @@
             this.tabPage4.Location = new System.Drawing.Point(4, 22);
             this.tabPage4.Name = "tabPage4";
             this.tabPage4.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage4.Size = new System.Drawing.Size(1574, 591);
+            this.tabPage4.Size = new System.Drawing.Size(1576, 593);
             this.tabPage4.TabIndex = 3;
-            this.tabPage4.Text = "E-shop files (experimental - SLOW)";
+            this.tabPage4.Text = "E-shop files";
             this.tabPage4.UseVisualStyleBackColor = true;
             // 
             // btnClearFilterEShop
@@ -2560,6 +2598,8 @@
             this.OLVEshop.AllColumns.Add(this.olvColumnGameRevisionEShop);
             this.OLVEshop.AllColumns.Add(this.olvColumnMasterKeyRevisionEShop);
             this.OLVEshop.AllColumns.Add(this.olvColumnDistributionType);
+            this.OLVEshop.AllColumns.Add(this.olvColumnFirmwareEShop);
+            this.OLVEshop.AllColumns.Add(this.olvColumnSDKVersionEShop);
             this.OLVEshop.CellEditUseWholeCell = false;
             this.OLVEshop.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.olvColumnTitleIDEShop,
@@ -2570,7 +2610,9 @@
             this.olvColumnDeveloperEShop,
             this.olvColumnGameRevisionEShop,
             this.olvColumnMasterKeyRevisionEShop,
-            this.olvColumnDistributionType});
+            this.olvColumnDistributionType,
+            this.olvColumnFirmwareEShop,
+            this.olvColumnSDKVersionEShop});
             this.OLVEshop.ContextMenuStrip = this.contextMenuStripEShop;
             this.OLVEshop.Cursor = System.Windows.Forms.Cursors.Default;
             this.OLVEshop.Dock = System.Windows.Forms.DockStyle.Fill;
@@ -2579,7 +2621,7 @@
             this.OLVEshop.Location = new System.Drawing.Point(3, 27);
             this.OLVEshop.Name = "OLVEshop";
             this.OLVEshop.ShowGroups = false;
-            this.OLVEshop.Size = new System.Drawing.Size(1568, 561);
+            this.OLVEshop.Size = new System.Drawing.Size(1570, 563);
             this.OLVEshop.TabIndex = 2;
             this.OLVEshop.UseCellFormatEvents = true;
             this.OLVEshop.UseCompatibleStateImageBehavior = false;
@@ -2601,7 +2643,7 @@
             this.olvColumnGameNameEShop.AspectName = "GameName";
             this.olvColumnGameNameEShop.Text = "Game title";
             this.olvColumnGameNameEShop.UseInitialLetterForGroup = true;
-            this.olvColumnGameNameEShop.Width = 344;
+            this.olvColumnGameNameEShop.Width = 280;
             // 
             // olvColumnROMSizeEshop
             // 
@@ -2615,14 +2657,14 @@
             // 
             this.olvColumnLanguagesEShop.AspectName = "Languages";
             this.olvColumnLanguagesEShop.Text = "Languages";
-            this.olvColumnLanguagesEShop.Width = 154;
+            this.olvColumnLanguagesEShop.Width = 100;
             // 
             // olvColumnFilePathEShop
             // 
             this.olvColumnFilePathEShop.AspectName = "FilePath";
             this.olvColumnFilePathEShop.Text = "Filename";
             this.olvColumnFilePathEShop.UseInitialLetterForGroup = true;
-            this.olvColumnFilePathEShop.Width = 322;
+            this.olvColumnFilePathEShop.Width = 280;
             // 
             // olvColumnDeveloperEShop
             // 
@@ -2648,6 +2690,18 @@
             this.olvColumnDistributionType.AspectName = "DistributionType";
             this.olvColumnDistributionType.Text = "Distribution";
             this.olvColumnDistributionType.Width = 72;
+            // 
+            // olvColumnFirmwareEShop
+            // 
+            this.olvColumnFirmwareEShop.AspectName = "Firmware";
+            this.olvColumnFirmwareEShop.Text = "Firmware";
+            this.olvColumnFirmwareEShop.Width = 100;
+            // 
+            // olvColumnSDKVersionEShop
+            // 
+            this.olvColumnSDKVersionEShop.AspectName = "SDKVersion";
+            this.olvColumnSDKVersionEShop.Text = "SDK Version";
+            this.olvColumnSDKVersionEShop.Width = 100;
             // 
             // contextMenuStripEShop
             // 
@@ -2765,7 +2819,7 @@
             this.toolStripMenuItem24});
             this.menuEShop.Location = new System.Drawing.Point(3, 3);
             this.menuEShop.Name = "menuEShop";
-            this.menuEShop.Size = new System.Drawing.Size(1568, 24);
+            this.menuEShop.Size = new System.Drawing.Size(1570, 24);
             this.menuEShop.TabIndex = 0;
             this.menuEShop.Text = "menuStrip2";
             // 
@@ -3050,6 +3104,27 @@
             this.tabPage5.Text = "Log";
             this.tabPage5.UseVisualStyleBackColor = true;
             // 
+            // panel6
+            // 
+            this.panel6.Controls.Add(this.richTextBoxLog);
+            this.panel6.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.panel6.Location = new System.Drawing.Point(3, 3);
+            this.panel6.Name = "panel6";
+            this.panel6.Size = new System.Drawing.Size(1570, 561);
+            this.panel6.TabIndex = 2;
+            // 
+            // richTextBoxLog
+            // 
+            this.richTextBoxLog.BackColor = System.Drawing.SystemColors.Window;
+            this.richTextBoxLog.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.richTextBoxLog.Location = new System.Drawing.Point(0, 0);
+            this.richTextBoxLog.Name = "richTextBoxLog";
+            this.richTextBoxLog.ReadOnly = true;
+            this.richTextBoxLog.Size = new System.Drawing.Size(1570, 561);
+            this.richTextBoxLog.TabIndex = 3;
+            this.richTextBoxLog.Text = "";
+            this.richTextBoxLog.TextChanged += new System.EventHandler(this.richTextBoxLog_TextChanged);
+            // 
             // panel7
             // 
             this.panel7.Controls.Add(this.btnClearLogFile);
@@ -3229,27 +3304,6 @@
             // 
             this.backgroundWorkerUpdateFiles.DoWork += new System.ComponentModel.DoWorkEventHandler(this.backgroundWorkerUpdateFiles_DoWork);
             // 
-            // panel6
-            // 
-            this.panel6.Controls.Add(this.richTextBoxLog);
-            this.panel6.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panel6.Location = new System.Drawing.Point(3, 3);
-            this.panel6.Name = "panel6";
-            this.panel6.Size = new System.Drawing.Size(1570, 561);
-            this.panel6.TabIndex = 2;
-            // 
-            // richTextBoxLog
-            // 
-            this.richTextBoxLog.BackColor = System.Drawing.SystemColors.Window;
-            this.richTextBoxLog.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.richTextBoxLog.Location = new System.Drawing.Point(0, 0);
-            this.richTextBoxLog.Name = "richTextBoxLog";
-            this.richTextBoxLog.ReadOnly = true;
-            this.richTextBoxLog.Size = new System.Drawing.Size(1570, 561);
-            this.richTextBoxLog.TabIndex = 3;
-            this.richTextBoxLog.Text = "";
-            this.richTextBoxLog.TextChanged += new System.EventHandler(this.richTextBoxLog_TextChanged);
-            // 
             // FrmMain
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -3302,12 +3356,12 @@
             this.menuEShop.ResumeLayout(false);
             this.menuEShop.PerformLayout();
             this.tabPage5.ResumeLayout(false);
+            this.panel6.ResumeLayout(false);
             this.panel7.ResumeLayout(false);
             this.statusStrip1.ResumeLayout(false);
             this.statusStrip1.PerformLayout();
             this.menuStrip1.ResumeLayout(false);
             this.menuStrip1.PerformLayout();
-            this.panel6.ResumeLayout(false);
             this.ResumeLayout(false);
 
         }
@@ -3655,6 +3709,12 @@
         private System.Windows.Forms.Button btnClearLogFile;
         private System.Windows.Forms.Panel panel6;
         private System.Windows.Forms.RichTextBox richTextBoxLog;
+        private BrightIdeasSoftware.OLVColumn olvColumnSDKVersionLocal;
+        private BrightIdeasSoftware.OLVColumn olvColumnSDKVersionSD;
+        private BrightIdeasSoftware.OLVColumn olvColumnSDKVersionEShop;
+        private BrightIdeasSoftware.OLVColumn olvColumnFirmwareLocal;
+        private BrightIdeasSoftware.OLVColumn olvColumnFirmwareSD;
+        private BrightIdeasSoftware.OLVColumn olvColumnFirmwareEShop;
     }
 }
 

--- a/Switch Backup Manager/Util.cs
+++ b/Switch Backup Manager/Util.cs
@@ -1474,7 +1474,7 @@ namespace Switch_Backup_Manager
                                 data.Languages = data_tmp.Languages;
                                 data.GameRevision = data_tmp.GameRevision;
                                 data.ProductCode = data_tmp.ProductCode;
-                                data.GameName = data_tmp.GameName + " [DLC]";
+                                data.GameName = data_tmp.GameName;// + " [DLC]";
                                 data.Developer = data_tmp.Developer;
                                 found = true;
                             }
@@ -1489,7 +1489,7 @@ namespace Switch_Backup_Manager
                                     data.Languages = data_tmp.Languages;
                                     data.GameRevision = data_tmp.GameRevision;
                                     data.ProductCode = data_tmp.ProductCode;
-                                    data.GameName = data_tmp.GameName + " [DLC]";
+                                    data.GameName = data_tmp.GameName;// + " [DLC]";
                                     data.Developer = data_tmp.Developer;
                                     found = true;
                                 }
@@ -1505,7 +1505,7 @@ namespace Switch_Backup_Manager
                                     data.Languages = data_tmp.Languages;
                                     data.GameRevision = data_tmp.GameRevision;
                                     data.ProductCode = data_tmp.ProductCode;
-                                    data.GameName = data_tmp.GameName + " [DLC]";
+                                    data.GameName = data_tmp.GameName;// + " [DLC]";
                                     data.Developer = data_tmp.Developer;
                                     found = true;
                                 }
@@ -1530,7 +1530,7 @@ namespace Switch_Backup_Manager
                                     }
                                     else
                                     {
-                                        gameName += " [DLC]";
+                                        //gameName += " [DLC]";
                                     }
 
                                     data.GameName = gameName;
@@ -1651,13 +1651,13 @@ namespace Switch_Backup_Manager
 
                     if (data.ContentType == "Patch")
                     {
-                        data.GameName = data.GameName + " [UPD]";
+                        data.GameName = data.GameName;// + " [UPD]";
                     }
 
                     //data.TitleIDBaseGame = data.TitleID;
                 }
 
-                data.GameName = data.GameName + " [v" + data.Version + "]";
+                //data.GameName = data.GameName + " [v" + data.Version + "]";
 
                 //Lets get SDK Version, Distribution Type and Masterkey revision
                 //This is far from the best aproach, but its what we have for now

--- a/Switch Backup Manager/Util.cs
+++ b/Switch Backup Manager/Util.cs
@@ -1303,71 +1303,284 @@ namespace Switch_Backup_Manager
 
             Process process = new Process();
             logger.Info("Adding NSP file: " + data.FileName);
+
             try
             {
-                //Directory.CreateDirectory("tmp");
-                process.StartInfo = new ProcessStartInfo
-                {
-                    WindowStyle = ProcessWindowStyle.Hidden,
-                    FileName = "hactool.exe",
-                    Arguments = "-t pfs0 " + "\""+ file +"\"" + " --outdir=tmp"
-                };
-                logger.Info("Extracting NSP file.");
-                process.Start();
-                process.WaitForExit();
-                process.Close();
+                MultiStream fileStream = GetFileStream(file);
 
-                List<string> listXML = new List<string>();
-                if (!Directory.Exists("tmp"))
-                {
-                    logger.Error("Directory tmp was not created ?!");                    
-                }
-                try
-                {
-                    logger.Info("found " + Directory.GetFiles("tmp", "*.xml").First());
-                    foreach (string f in Directory.GetFiles("tmp", "*.xml"))
-                    {
-                        listXML.Add(f);
-                        break;
-                    }
-                } catch (Exception e)
-                {
-                    logger.Error(e.StackTrace);
-                }
-
-                XDocument xml = XDocument.Load(listXML.First());
-                data.TitleID = xml.Element("ContentMeta").Element("Id").Value.Remove(1,2).ToUpper();                
-                data.ContentType = xml.Element("ContentMeta").Element("Type").Value;
-                data.Version = xml.Element("ContentMeta").Element("Version").Value;
                 string ncaTarget = "";
 
-                string titleIDBaseGame = data.TitleID;
-                if (data.ContentType != "Application")
+                List<char> chars = new List<char>();
+                byte[] array = new byte[16];
+                byte[] array2 = new byte[24];
+                fileStream.Read(array, 0, 16);
+                PFS0.PFS0_Headers[0] = new PFS0.PFS0_Header(array);
+                if (!PFS0.PFS0_Headers[0].Magic.Contains("PFS0"))
                 {
-                    string titleIdBase = data.TitleID.Substring(0, 13);
-                    if (data.ContentType == "Patch") //UPDATE
+                    return data;
+                }
+                PFS0.PFS0_Entry[] array3;
+                array3 = new PFS0.PFS0_Entry[Math.Max(PFS0.PFS0_Headers[0].FileCount, 20)]; //Dump of TitleID 01009AA000FAA000 reports more than 10000000 files here, so it breaks the program. Standard is to have only 20 files
+
+                for (int m = 0; m < PFS0.PFS0_Headers[0].FileCount; m++)
+                {
+                    fileStream.Position = 16 + 24 * m;
+                    fileStream.Read(array2, 0, 24);
+                    array3[m] = new PFS0.PFS0_Entry(array2);
+
+                    if (m == 19) //Dump of TitleID 01009AA000FAA000 reports more than 10000000 files here, so it breaks the program. Standard is to have only 20 files
                     {
-                        titleIDBaseGame = titleIdBase + "000";
-                    } else //DLC
-                    {
-                        long tmp = long.Parse(titleIdBase, System.Globalization.NumberStyles.HexNumber) - 1;
-                        titleIDBaseGame = string.Format("0{0:X8}", tmp) + "000";
+                        break;
                     }
                 }
-                data.TitleIDBaseGame = titleIDBaseGame;
+                for (int n = 0; n < PFS0.PFS0_Headers[0].FileCount; n++)
+                {
+                    fileStream.Position = 16 + 24 * PFS0.PFS0_Headers[0].FileCount + array3[n].Name_ptr;
+                    int num4;
+                    while ((num4 = fileStream.ReadByte()) != 0 && num4 != 0)
+                    {
+                        chars.Add((char)num4);
+                    }
+                    array3[n].Name = new string(chars.ToArray());
+                    chars.Clear();
+
+                    if (array3[n].Name.EndsWith(".xml"))
+                    {
+                        byte[] array4 = new byte[array3[n].Size];
+                        fileStream.Position = 16 + 24 * PFS0.PFS0_Headers[0].FileCount + PFS0.PFS0_Headers[0].StringTableSize + array3[n].Offset;
+                        fileStream.Read(array4, 0, (int)array3[n].Size);
+
+                        XDocument xml = XDocument.Parse(Encoding.UTF8.GetString(array4));
+                        data.TitleID = xml.Element("ContentMeta").Element("Id").Value.Remove(1, 2).ToUpper();
+                        data.ContentType = xml.Element("ContentMeta").Element("Type").Value;
+                        data.Version = xml.Element("ContentMeta").Element("Version").Value;
+
+                        //0100000000000816,ALL,v65796 v131162 v196628 v262164 v201327002 v201392178 v201457684 v268435656 v268501002 v269484082 v335544750 v335609886 v335675432 v336592976,2.0.0 2.1.0 2.2.0 2.3.0 3.0.0 3.0.1 3.0.2 4.0.0 4.0.1 4.1.0 5.0.0 5.0.1 5.0.2 5.1.0
+                        data.Firmware = "";
+                        long Firmware = Convert.ToInt64(xml.Element("ContentMeta").Element("RequiredSystemVersion").Value) % 0x100000000;
+                        if (Firmware <= 450)
+                        {
+                            data.Firmware = "1.0.0";
+                        }
+                        else if (Firmware <= 65796)
+                        {
+                            data.Firmware = "2.0.0";
+                        }
+                        else if (Firmware <= 131162)
+                        {
+                            data.Firmware = "2.1.0";
+                        }
+                        else if (Firmware <= 196628)
+                        {
+                            data.Firmware = "2.2.0";
+                        }
+                        else if (Firmware <= 262164)
+                        {
+                            data.Firmware = "2.3.0";
+                        }
+                        else if (Firmware <= 201327002)
+                        {
+                            data.Firmware = "3.0.0";
+                        }
+                        else if (Firmware <= 201392178)
+                        {
+                            data.Firmware = "3.0.1";
+                        }
+                        else if (Firmware <= 201457684)
+                        {
+                            data.Firmware = "3.0.2";
+                        }
+                        else if (Firmware <= 268435656)
+                        {
+                            data.Firmware = "4.0.0";
+                        }
+                        else if (Firmware <= 268501002)
+                        {
+                            data.Firmware = "4.0.1";
+                        }
+                        else if (Firmware <= 269484082)
+                        {
+                            data.Firmware = "4.1.0";
+                        }
+                        else if (Firmware <= 335544750)
+                        {
+                            data.Firmware = "5.0.0";
+                        }
+                        else if (Firmware <= 335609886)
+                        {
+                            data.Firmware = "5.0.1";
+                        }
+                        else if (Firmware <= 335675432)
+                        {
+                            data.Firmware = "5.0.2";
+                        }
+                        else if (Firmware <= 336592976)
+                        {
+                            data.Firmware = "5.1.0";
+                        }
+                        else
+                        {
+                            data.Firmware = Convert.ToString(Firmware);
+                        }
+
+                        string titleIDBaseGame = data.TitleID;
+                        if (data.ContentType != "Application")
+                        {
+                            string titleIdBase = data.TitleID.Substring(0, 13);
+                            if (data.ContentType == "Patch") //UPDATE
+                            {
+                                titleIDBaseGame = titleIdBase + "000";
+                            }
+                            else //DLC
+                            {
+                                long tmp = long.Parse(titleIdBase, System.Globalization.NumberStyles.HexNumber) - 1;
+                                titleIDBaseGame = string.Format("0{0:X8}", tmp) + "000";
+                            }
+                        }
+                        data.TitleIDBaseGame = titleIDBaseGame;
+
+                        if (data.ContentType != "AddOnContent")
+                        {
+                            foreach (XElement xe in xml.Descendants("Content"))
+                            {
+                                if (xe.Element("Type").Value != "Control")
+                                {
+                                    continue;
+                                }
+
+                                ncaTarget = xe.Element("Id").Value + ".nca";
+                                break;
+                            }
+                        }
+                        else //This is a DLC
+                        {
+                            foreach (XElement xe in xml.Descendants("Content"))
+                            {
+                                if (xe.Element("Type").Value != "Meta")
+                                {
+                                    continue;
+                                }
+
+                                ncaTarget = xe.Element("Id").Value + ".cnmt.nca";
+                                break;
+                            }
+                            bool found = false;
+
+                            FileData data_tmp = null;
+                            FrmMain.LocalNSPFilesList.TryGetValue(data.TitleIDBaseGame, out data_tmp); //Try to find on NSP List
+                            if (data_tmp != null)
+                            {
+                                data.Region_Icon = data_tmp.Region_Icon;
+                                data.Languages = data_tmp.Languages;
+                                data.GameRevision = data_tmp.GameRevision;
+                                data.ProductCode = data_tmp.ProductCode;
+                                data.GameName = data_tmp.GameName + " [DLC]";
+                                data.Developer = data_tmp.Developer;
+                                found = true;
+                            }
+
+                            if (!found)
+                            {
+                                data_tmp = null;
+                                FrmMain.SceneReleasesList.TryGetValue(data.TitleIDBaseGame, out data_tmp); //Try to find on Scene List
+                                if (data_tmp != null)
+                                {
+                                    data.Region_Icon = data_tmp.Region_Icon;
+                                    data.Languages = data_tmp.Languages;
+                                    data.GameRevision = data_tmp.GameRevision;
+                                    data.ProductCode = data_tmp.ProductCode;
+                                    data.GameName = data_tmp.GameName + " [DLC]";
+                                    data.Developer = data_tmp.Developer;
+                                    found = true;
+                                }
+                            }
+
+                            if (!found)
+                            {
+                                data_tmp = null;
+                                FrmMain.LocalFilesList.TryGetValue(data.TitleIDBaseGame, out data_tmp); //Try to find on Local XCI List
+                                if (data_tmp != null)
+                                {
+                                    data.Region_Icon = data_tmp.Region_Icon;
+                                    data.Languages = data_tmp.Languages;
+                                    data.GameRevision = data_tmp.GameRevision;
+                                    data.ProductCode = data_tmp.ProductCode;
+                                    data.GameName = data_tmp.GameName + " [DLC]";
+                                    data.Developer = data_tmp.Developer;
+                                    found = true;
+                                }
+                            }
+
+                            //Last resource, look at titlekeys
+                            if (!found)
+                            {
+                                if (UseTitleKeys && File.Exists(TITLE_KEYS))
+                                {
+                                    string gameName = (from x in File.ReadAllLines(TITLE_KEYS)
+                                                       select x.Split('|') into x
+                                                       where x.Length > 1
+                                                       select x).ToDictionary((string[] x) => x[0].Trim(), (string[] x) => x[2])[data.TitleIDBaseGame].ToLower();
+
+                                    if (gameName.Trim() == "")
+                                    {
+                                        gameName = (from x in File.ReadAllLines(TITLE_KEYS)
+                                                    select x.Split('|') into x
+                                                    where x.Length > 1
+                                                    select x).ToDictionary((string[] x) => x[0].Trim(), (string[] x) => x[2])[data.TitleID].ToLower();
+                                    }
+                                    else
+                                    {
+                                        gameName += " [DLC]";
+                                    }
+
+                                    data.GameName = gameName;
+                                }
+                            }
+                        }
+
+                        //break;
+                    }
+
+                    if (n == 19) //Dump of TitleID 01009AA000FAA000 reports more than 10000000 files here, so it breaks the program. Standard is to have only 20 files
+                    {
+                        break;
+                    }
+                }
+
+                for (int n = 0; n < PFS0.PFS0_Headers[0].FileCount; n++)
+                {
+                    if (array3[n].Name.Equals(ncaTarget))
+                    {
+                        if (!Directory.Exists("tmp"))
+                        {
+                            Directory.CreateDirectory("tmp");
+                        }
+
+                        byte[] array5 = new byte[64 * 1024];
+                        fileStream.Position = 16 + 24 * PFS0.PFS0_Headers[0].FileCount + PFS0.PFS0_Headers[0].StringTableSize + array3[n].Offset;
+
+                        using (Stream output = File.Create("tmp\\" + ncaTarget))
+                        {
+                            long Size = array3[n].Size;
+                            int result = 0;
+                            while ((result = fileStream.Read(array5, 0, (int)Math.Min(array5.Length, Size))) > 0)
+                            {
+                                output.Write(array5, 0, result);
+                                Size -= result;
+                            }
+                        }
+
+                        break;
+                    }
+
+                    if (n == 19) //Dump of TitleID 01009AA000FAA000 reports more than 10000000 files here, so it breaks the program. Standard is to have only 20 files
+                    {
+                        break;
+                    }
+                }
 
                 if (data.ContentType != "AddOnContent")
                 {
-                    foreach (XElement xe in xml.Descendants("Content"))
-                    {
-                        if (xe.Element("Type").Value != "Control")
-                        {
-                            continue;
-                        }
-
-                        ncaTarget = xe.Element("Id").Value + ".nca";
-                        break;
-                    }
                     process = new Process();
                     process.StartInfo = new ProcessStartInfo
                     {
@@ -1443,90 +1656,6 @@ namespace Switch_Backup_Manager
 
                     //data.TitleIDBaseGame = data.TitleID;
                 }
-                else //This is a DLC
-                {
-                    foreach (XElement xe in xml.Descendants("Content"))
-                    {
-                        if (xe.Element("Type").Value != "Meta")
-                        {
-                            continue;
-                        }
-
-                        ncaTarget = xe.Element("Id").Value + ".cnmt.nca";
-                        break;
-                    }
-                    bool found = false;
-
-                    FileData data_tmp = null;
-                    FrmMain.LocalNSPFilesList.TryGetValue(data.TitleIDBaseGame, out data_tmp); //Try to find on NSP List
-                    if (data_tmp != null)
-                    {
-                        data.Region_Icon = data_tmp.Region_Icon;
-                        data.Languages = data_tmp.Languages;
-                        data.GameRevision = data_tmp.GameRevision;
-                        data.ProductCode = data_tmp.ProductCode;
-                        data.GameName = data_tmp.GameName + " [DLC]";
-                        data.Developer = data_tmp.Developer;
-                        found = true;
-                    }
-
-                    if (!found)
-                    {
-                        data_tmp = null;
-                        FrmMain.SceneReleasesList.TryGetValue(data.TitleIDBaseGame, out data_tmp); //Try to find on Scene List
-                        if (data_tmp != null)
-                        {
-                            data.Region_Icon = data_tmp.Region_Icon;
-                            data.Languages = data_tmp.Languages;
-                            data.GameRevision = data_tmp.GameRevision;
-                            data.ProductCode = data_tmp.ProductCode;
-                            data.GameName = data_tmp.GameName + " [DLC]";
-                            data.Developer = data_tmp.Developer;
-                            found = true;
-                        }
-                    }
-
-                    if (!found)
-                    {
-                        data_tmp = null;
-                        FrmMain.LocalFilesList.TryGetValue(data.TitleIDBaseGame, out data_tmp); //Try to find on Local XCI List
-                        if (data_tmp != null)
-                        {
-                            data.Region_Icon = data_tmp.Region_Icon;
-                            data.Languages = data_tmp.Languages;
-                            data.GameRevision = data_tmp.GameRevision;
-                            data.ProductCode = data_tmp.ProductCode;
-                            data.GameName = data_tmp.GameName + " [DLC]";
-                            data.Developer = data_tmp.Developer;
-                            found = true;
-                        }
-                    }
-
-                    //Last resource, look at titlekeys
-                    if (!found)
-                    {
-                        if (UseTitleKeys && File.Exists(TITLE_KEYS))
-                        {
-                            string gameName = (from x in File.ReadAllLines(TITLE_KEYS)
-                                               select x.Split('|') into x
-                                               where x.Length > 1
-                                               select x).ToDictionary((string[] x) => x[0].Trim(), (string[] x) => x[2])[data.TitleIDBaseGame].ToLower();
-                            
-                            if (gameName.Trim() == "") {
-                                gameName = (from x in File.ReadAllLines(TITLE_KEYS)
-                                            select x.Split('|') into x
-                                            where x.Length > 1
-                                            select x).ToDictionary((string[] x) => x[0].Trim(), (string[] x) => x[2])[data.TitleID].ToLower();
-                            } else
-                            {
-                                gameName += " [DLC]";
-                            }
-
-                            data.GameName = gameName;
-                        }
-                    }
-
-                }
 
                 data.GameName = data.GameName + " [v" + data.Version + "]";
 
@@ -1554,10 +1683,12 @@ namespace Switch_Backup_Manager
                     if (strArray[0] == "SDK Version")
                     {
                         data.SDKVersion = strArray[1].Trim();
-                    } else if (strArray[0] == "Distribution type")
+                    }
+                    else if (strArray[0] == "Distribution type")
                     {
                         data.DistributionType = strArray[1].Trim();
-                    } else if (strArray[0] == "Master Key Revision")
+                    }
+                    else if (strArray[0] == "Master Key Revision")
                     {
                         data.MasterKeyRevision = strArray[1].Trim();
                         break;
@@ -1569,7 +1700,8 @@ namespace Switch_Backup_Manager
             catch (Exception e)
             {
                 logger.Error(e.StackTrace);
-            } finally
+            }
+            finally
             {
                 Directory.Delete("tmp", true);
             }


### PR DESCRIPTION
This PR implements NSP info extraction based on my previous gist https://gist.github.com/garoxas/b41b7acca5c4c833fe446c22951cf005
What it does basically remove the entire files extraction logic using hactool and only extract necessary files (1 XML and 1 NCA file) instead, and proceed from that

Also I added required FW version info for NSP files