### PR TITLE
make Description text more readable

### DIFF
--- a/Switch Backup Manager/Form1.Designer.cs
+++ b/Switch Backup Manager/Form1.Designer.cs
@@ -3658,7 +3658,7 @@
             // 
             this.bottonPanelToolStripMenuItem.Name = "bottonPanelToolStripMenuItem";
             this.bottonPanelToolStripMenuItem.Size = new System.Drawing.Size(142, 22);
-            this.bottonPanelToolStripMenuItem.Text = "&Botton panel";
+            this.bottonPanelToolStripMenuItem.Text = "&Bottom panel";
             this.bottonPanelToolStripMenuItem.Click += new System.EventHandler(this.bottonPanelToolStripMenuItem_Click);
             // 
             // leftPanelToolStripMenuItem

--- a/Switch Backup Manager/Form1.cs
+++ b/Switch Backup Manager/Form1.cs
@@ -13,6 +13,7 @@ using System.Xml.Linq;
 using BrightIdeasSoftware;
 using HtmlAgilityPack;
 using Microsoft.WindowsAPICodePack.Dialogs;
+using System.Text.RegularExpressions;
 
 namespace Switch_Backup_Manager
 {
@@ -673,7 +674,8 @@ namespace Switch_Backup_Manager
                         categories += cat + "\n";
                     }
 
-                    richTextBoxGameDescription.Text = (data2.Description.Trim() != "") ? data2.Description : Properties.Resources.EN_Not_Available;
+                    richTextBoxGameDescription.Text = (data2.Description.Trim() != "") ?
+                        Regex.Replace(Regex.Replace(data2.Description.Trim(), "(\n +){2,}", "\n\n"), "\n +", " ") : Properties.Resources.EN_Not_Available;
                     lblNumberOfPlayers.Text = (data2.NumberOfPlayers.Trim() != "") ? data2.NumberOfPlayers : Properties.Resources.EN_Not_Available;
                     lblReleaseDate.Text = (data2.ReleaseDate.Trim() != "") ? data2.ReleaseDate : Properties.Resources.EN_Not_Available;
                     lblPublisher.Text = (data2.Publisher.Trim() != "") ? data2.Publisher : Properties.Resources.EN_Not_Available;
@@ -1014,7 +1016,8 @@ namespace Switch_Backup_Manager
                 textBoxFirmware.Text = this.TitleToEdit.Firmware;
                 textBoxReleaseDate.Text = this.TitleToEdit.ReleaseDate;
                 textBoxPlayers.Text = this.TitleToEdit.NumberOfPlayers;
-                richTextBoxDescription.Text = this.TitleToEdit.Description;
+                richTextBoxDescription.Text = (this.TitleToEdit.Description.Trim() != "") ?
+                    Regex.Replace(Regex.Replace(this.TitleToEdit.Description.Trim(), "(\n +){2,}", "\n\n"), "\n +", " ") : "";
             }
         }
 

--- a/Switch Backup Manager/Util.cs
+++ b/Switch Backup Manager/Util.cs
@@ -274,7 +274,10 @@ namespace Switch_Backup_Manager
 
                 try
                 {
-                    data.Description = System.Net.WebUtility.HtmlDecode(description);
+                    description = System.Net.WebUtility.HtmlDecode(description);
+                    if (!String.IsNullOrEmpty(description))
+                        description = Regex.Replace(Regex.Replace(description.Trim(), "(\n +){2,}", "\n\n"), "\n +", " ");
+                    data.Description = description;
                 } catch { }
                 
                 try
@@ -2586,7 +2589,10 @@ namespace Switch_Backup_Manager
                 }
                 if (xe.Element("Description") != null)
                 {
-                    result.Description = xe.Element("Description").Value;
+                    string description = xe.Element("Description").Value;
+                    if (!String.IsNullOrEmpty(description))
+                        description = Regex.Replace(Regex.Replace(description.Trim(), "(\n +){2,}", "\n\n"), "\n +", " ");
+                    result.Description = description;
                 }
                 if (xe.Element("Publisher") != null)
                 {

--- a/Switch Backup Manager/Util.cs
+++ b/Switch Backup Manager/Util.cs
@@ -274,10 +274,7 @@ namespace Switch_Backup_Manager
 
                 try
                 {
-                    description = System.Net.WebUtility.HtmlDecode(description);
-                    if (!String.IsNullOrEmpty(description))
-                        description = Regex.Replace(Regex.Replace(description.Trim(), "(\n +){2,}", "\n\n"), "\n +", " ");
-                    data.Description = description;
+                    data.Description = System.Net.WebUtility.HtmlDecode(description);
                 } catch { }
                 
                 try
@@ -2589,10 +2586,7 @@ namespace Switch_Backup_Manager
                 }
                 if (xe.Element("Description") != null)
                 {
-                    string description = xe.Element("Description").Value;
-                    if (!String.IsNullOrEmpty(description))
-                        description = Regex.Replace(Regex.Replace(description.Trim(), "(\n +){2,}", "\n\n"), "\n +", " ");
-                    result.Description = description;
+                    result.Description = xe.Element("Description").Value;
                 }
                 if (xe.Element("Publisher") != null)
                 {


### PR DESCRIPTION
https://gbatemp.net/threads/switch-backup-manager-1-0.511143/page-14#post-8211691

please note that I need to use 2 regex so it doesn't break paragraph separation as for example with Mario + Rabbids description
```
      The Mushroom Kingdom has been torn apart by a mysterious vortex, 
      transporting the chaotic Rabbids into this once-peaceful land. To 
      restore order, Mario, Luigi, Princess Peach, and Yoshi must team up with 
      a whole new crew: four Rabbids heroes! Together, they will battle with 
      weapons through four worlds filled with combat, puzzles, and 
      unpredictable enemies.
    
      Developed exclusively for the Nintendo Switch™ system, Mario + Rabbids 
      Kingdom Battle is the best of the Mario and Rabbids franchises, 
      combining all that you love about Mario's iconic universe with the 
      side-splitting antics of the Rabbids.
```

we don't want them to be displayed as a single line