### PR TITLE
quick and dirty fix for #42

### DIFF
--- a/Switch Backup Manager/Util.cs
+++ b/Switch Backup Manager/Util.cs
@@ -2350,7 +2350,7 @@ namespace Switch_Backup_Manager
                 if (getMKey())
                 {
                     List<string> ncaTarget = new List<string>();
-                    Version GameRevision = new Version();
+                    string GameRevision = "";
 
                     for (int si = 0; si < SecureSize.Length; si++)
                     {
@@ -2463,9 +2463,19 @@ namespace Switch_Backup_Manager
                                 NACP.NACP_Datas[0] = new NACP.NACP_Data(source.Skip(0x3000).Take(0x1000).ToArray());
 
                                 string GameVer = NACP.NACP_Datas[0].GameVer.Replace("\0", "");
-                                if (Version.Parse(GameVer).CompareTo(GameRevision) > 0)
+
+                                Version version1, version2;
+                                if (!Version.TryParse(Regex.Replace(GameRevision, @"[^\d.]", ""), out version1))
                                 {
-                                    GameRevision = Version.Parse(GameVer);
+                                    version1 = new Version();
+                                }
+                                if (!Version.TryParse(Regex.Replace(GameVer, @"[^\d.]", ""), out version2))
+                                {
+                                    version2 = new Version();
+                                }
+                                if (version2.CompareTo(version1) > 0)
+                                {
+                                    GameRevision = GameVer;
 
                                     result.Region_Icon = new Dictionary<string, string>();
                                     result.Languages = new List<string>();


### PR DESCRIPTION
this is just a quick fix for #42 to prevent exception occurs while iterating XCI files with invalid version number (Wonder Boy: The Dragons Trap US version with Title ID 0100256006BF8000 for example)
ideally I need to know the root cause of this issue, but since I didn't get any volunteers that willing to get me the files I needed (or even the version string for the game), so I just came up with dirty solution like this

I simply removed non supported characters in the version string to prevent Version.Parse throw an exception, however this might not work properly if for example there 2 control.nacp in the XCI with the following version numbers, 1.0.0a and 1.0.0b
because I simply removed everything but number and decimal symbol, both will end up as version 1.0.0

but at least, no more missing XCI this way. it's just the version number will not be reported correctly