### PR TITLE
Fix to add scene release info when adding an NSP file

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Complete Switch Backups management tool
 
 ## Changelog
 
+v 1.1.5
+  - Fix #50: New autorenaming pattern is not used at runtime;
+  - Fix #52: NSWDB site changed something that prevents the program of downloading their xml file. 
+
 * 1.1.4
   - Fix #47: Some NSP update files were showing errors when adding to database (010065e003fd8800, 0100830004fb6800, 0100760002048800, 01005ee0036ec800, ..)
   - fix XCI files skipped when version number is non standard, fix #42 #44
@@ -109,6 +113,6 @@ Complete Switch Backups management tool
 
 ## Source & Binaries
 * [GitHub](https://github.com/gibaBR/Switch-Backup-Manager/archive/master.zip)
-* [Release 1.1.1](https://github.com/gibaBR/Switch-Backup-Manager/releases/tag/v1.1.1)
+* [Release 1.1.5](https://github.com/gibaBR/Switch-Backup-Manager/releases/tag/v1.1.5)
 
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ Complete Switch Backups management tool
 
 ## Changelog
 
+* 1.1.4
+  - Fix #47: Some NSP update files were showing errors when adding to database (010065e003fd8800, 0100830004fb6800, 0100760002048800, 01005ee0036ec800, ..)
+  - fix XCI files skipped when version number is non standard, fix #42 #44
+
+* 1.1.3
+  - get correct XCI Game Revision, fix #37 by @garoxas / @Garou;
+  - Fixed filter for content type (dlc, base game, update) not working. Also, this filter is now saved on program preferences (will persist between sessions);
+  - Separate renaming paterns for XCI and NSP files;
+  - User can now limit filename size for NSP files.
+
 * 1.1.2
   - Correct text format for game description by @garoxas / @Garou
   - Fixed #38 (Issue witch manual scrape.)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Complete Switch Backups management tool
 
 ## Changelog
 
-v 1.1.5
+* 1.1.5
   - Fix #50: New autorenaming pattern is not used at runtime;
   - Fix #52: NSWDB site changed something that prevents the program of downloading their xml file. 
 

--- a/Switch Backup Manager/FileData.cs
+++ b/Switch Backup Manager/FileData.cs
@@ -11,6 +11,7 @@ namespace Switch_Backup_Manager
     {
         public FileData () //Default constructor
         {
+            this.Found = "";
             this.FilePath = "";
             this.FileName = "";
             this.FileNameWithExt = "";
@@ -50,7 +51,7 @@ namespace Switch_Backup_Manager
             this.ESRB = 0;
         }
 
-        public FileData(string FilePath, string FileName, string FileNameWithExt, string ROMSize, long ROMSizeBytes, 
+        public FileData(string Found, string FilePath, string FileName, string FileNameWithExt, string ROMSize, long ROMSizeBytes, 
             string UsedSpace, long UsedSpaceBytes, string TitleID, string TitleIDBaseGame, string GameName, 
             string Developer, string GameRevision, string ProductCode, string SDKVersion, string CartSize, 
             string MasterKeyRevision, Dictionary<string, string> Region_Icon, List<string> Languages, string Languages_resumed, 
@@ -58,6 +59,7 @@ namespace Switch_Backup_Manager
             string DistributionType, int IdScene, string ContentType, string Version, bool HasExtendedInfo, string Description, 
             string Publisher, string ReleaseDate, string NumberOfPlayers, List<string> Categories, int ESRB)
         {
+            this.Found = Found;
             this.FilePath = FilePath;
             this.FileName = FileName;
             this.FileNameWithExt = FileNameWithExt;
@@ -97,6 +99,7 @@ namespace Switch_Backup_Manager
             this.ESRB = ESRB;
         }
 
+        public string Found { get; set; }
         public string FilePath { get; set; }
         public string FileName { get; set; }
         public string FileNameWithExt { get; set; }

--- a/Switch Backup Manager/Form1.Designer.cs
+++ b/Switch Backup Manager/Form1.Designer.cs
@@ -238,7 +238,7 @@
             this.cbxFilterScene = new System.Windows.Forms.ComboBox();
             this.OLVSceneList = new BrightIdeasSoftware.ObjectListView();
             this.olvColumnFound = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
-            this.olvColumnTitleIDScene = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
+            this.olvColumnSceneID = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
             this.olvColumnGameNameScene = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
             this.sizeColumnROMSizeScene = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
             this.olvColumnDeveloperScene = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
@@ -246,10 +246,10 @@
             this.olvColumnLanguagesScene = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
             this.olvColumnGroupScene = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
             this.olvColumnCartSizeScene = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
+            this.olvColumnTitleIDScene = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
             this.olvColumnSerialScene = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
             this.olvColumnFirmwareScene = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
             this.olvColumnCardTypeScene = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
-            this.olvColumnSceneID = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
             this.contextMenuStripScene = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.copyInfoToClipboardToolStripMenuItem3 = new System.Windows.Forms.ToolStripMenuItem();
             this.menuStrip3 = new System.Windows.Forms.MenuStrip();
@@ -2236,7 +2236,7 @@
             this.tabPage3.Location = new System.Drawing.Point(4, 22);
             this.tabPage3.Name = "tabPage3";
             this.tabPage3.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage3.Size = new System.Drawing.Size(1519, 492);
+            this.tabPage3.Size = new System.Drawing.Size(1517, 490);
             this.tabPage3.TabIndex = 2;
             this.tabPage3.Text = "Scene releases";
             this.tabPage3.UseVisualStyleBackColor = true;
@@ -2252,7 +2252,7 @@
             this.panel4.Dock = System.Windows.Forms.DockStyle.Fill;
             this.panel4.Location = new System.Drawing.Point(3, 3);
             this.panel4.Name = "panel4";
-            this.panel4.Size = new System.Drawing.Size(1513, 486);
+            this.panel4.Size = new System.Drawing.Size(1511, 484);
             this.panel4.TabIndex = 0;
             // 
             // btnClearFilterScene
@@ -2295,7 +2295,7 @@
             // OLVSceneList
             // 
             this.OLVSceneList.AllColumns.Add(this.olvColumnFound);
-            this.OLVSceneList.AllColumns.Add(this.olvColumnTitleIDScene);
+            this.OLVSceneList.AllColumns.Add(this.olvColumnSceneID);
             this.OLVSceneList.AllColumns.Add(this.olvColumnGameNameScene);
             this.OLVSceneList.AllColumns.Add(this.sizeColumnROMSizeScene);
             this.OLVSceneList.AllColumns.Add(this.olvColumnDeveloperScene);
@@ -2303,14 +2303,14 @@
             this.OLVSceneList.AllColumns.Add(this.olvColumnLanguagesScene);
             this.OLVSceneList.AllColumns.Add(this.olvColumnGroupScene);
             this.OLVSceneList.AllColumns.Add(this.olvColumnCartSizeScene);
+            this.OLVSceneList.AllColumns.Add(this.olvColumnTitleIDScene);
             this.OLVSceneList.AllColumns.Add(this.olvColumnSerialScene);
             this.OLVSceneList.AllColumns.Add(this.olvColumnFirmwareScene);
             this.OLVSceneList.AllColumns.Add(this.olvColumnCardTypeScene);
-            this.OLVSceneList.AllColumns.Add(this.olvColumnSceneID);
             this.OLVSceneList.CellEditUseWholeCell = false;
             this.OLVSceneList.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.olvColumnFound,
-            this.olvColumnTitleIDScene,
+            this.olvColumnSceneID,
             this.olvColumnGameNameScene,
             this.sizeColumnROMSizeScene,
             this.olvColumnDeveloperScene,
@@ -2318,10 +2318,10 @@
             this.olvColumnLanguagesScene,
             this.olvColumnGroupScene,
             this.olvColumnCartSizeScene,
+            this.olvColumnTitleIDScene,
             this.olvColumnSerialScene,
             this.olvColumnFirmwareScene,
-            this.olvColumnCardTypeScene,
-            this.olvColumnSceneID});
+            this.olvColumnCardTypeScene});
             this.OLVSceneList.ContextMenuStrip = this.contextMenuStripScene;
             this.OLVSceneList.Cursor = System.Windows.Forms.Cursors.Default;
             this.OLVSceneList.Dock = System.Windows.Forms.DockStyle.Fill;
@@ -2330,7 +2330,7 @@
             this.OLVSceneList.Location = new System.Drawing.Point(0, 24);
             this.OLVSceneList.Name = "OLVSceneList";
             this.OLVSceneList.ShowGroups = false;
-            this.OLVSceneList.Size = new System.Drawing.Size(1513, 462);
+            this.OLVSceneList.Size = new System.Drawing.Size(1511, 460);
             this.OLVSceneList.TabIndex = 6;
             this.OLVSceneList.UseCellFormatEvents = true;
             this.OLVSceneList.UseCompatibleStateImageBehavior = false;
@@ -2344,11 +2344,12 @@
             this.olvColumnFound.AspectName = "Found";
             this.olvColumnFound.Text = "Found";
             // 
-            // olvColumnTitleIDScene
+            // olvColumnSceneID
             // 
-            this.olvColumnTitleIDScene.AspectName = "TitleID";
-            this.olvColumnTitleIDScene.Text = "Title ID";
-            this.olvColumnTitleIDScene.Width = 124;
+            this.olvColumnSceneID.AspectName = "IdScene";
+            this.olvColumnSceneID.DisplayIndex = 12;
+            this.olvColumnSceneID.Text = "ID";
+            this.olvColumnSceneID.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
             // 
             // olvColumnGameNameScene
             // 
@@ -2395,9 +2396,17 @@
             this.olvColumnCartSizeScene.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             this.olvColumnCartSizeScene.Width = 74;
             // 
+            // olvColumnTitleIDScene
+            // 
+            this.olvColumnTitleIDScene.AspectName = "TitleID";
+            this.olvColumnTitleIDScene.DisplayIndex = 1;
+            this.olvColumnTitleIDScene.Text = "Title ID";
+            this.olvColumnTitleIDScene.Width = 124;
+            // 
             // olvColumnSerialScene
             // 
             this.olvColumnSerialScene.AspectName = "Serial";
+            this.olvColumnSerialScene.DisplayIndex = 9;
             this.olvColumnSerialScene.Text = "Serial number";
             this.olvColumnSerialScene.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
             this.olvColumnSerialScene.Width = 83;
@@ -2405,6 +2414,7 @@
             // olvColumnFirmwareScene
             // 
             this.olvColumnFirmwareScene.AspectName = "Firmware";
+            this.olvColumnFirmwareScene.DisplayIndex = 10;
             this.olvColumnFirmwareScene.Text = "Firmware";
             this.olvColumnFirmwareScene.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
             this.olvColumnFirmwareScene.Width = 93;
@@ -2412,15 +2422,10 @@
             // olvColumnCardTypeScene
             // 
             this.olvColumnCardTypeScene.AspectName = "Cardtype";
+            this.olvColumnCardTypeScene.DisplayIndex = 11;
             this.olvColumnCardTypeScene.Text = "Card type";
             this.olvColumnCardTypeScene.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
             this.olvColumnCardTypeScene.Width = 57;
-            // 
-            // olvColumnSceneID
-            // 
-            this.olvColumnSceneID.AspectName = "IdScene";
-            this.olvColumnSceneID.Text = "ID";
-            this.olvColumnSceneID.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
             // 
             // contextMenuStripScene
             // 
@@ -2449,7 +2454,7 @@
             this.toolStripMenuItem85});
             this.menuStrip3.Location = new System.Drawing.Point(0, 0);
             this.menuStrip3.Name = "menuStrip3";
-            this.menuStrip3.Size = new System.Drawing.Size(1513, 24);
+            this.menuStrip3.Size = new System.Drawing.Size(1511, 24);
             this.menuStrip3.TabIndex = 5;
             this.menuStrip3.Text = "menuStrip3";
             // 
@@ -2880,7 +2885,8 @@
             this.olvColumnSDKVersionEShop,
             this.olvColumnReleaseDateEshop,
             this.olvColumnNumberOfPlayersEshop,
-            this.olvColumnCategoriesEShop});
+            this.olvColumnCategoriesEShop,
+            this.olvColumnContentTypeEShop});
             this.OLVEshop.ContextMenuStrip = this.contextMenuEShopList;
             this.OLVEshop.Cursor = System.Windows.Forms.Cursors.Default;
             this.OLVEshop.Dock = System.Windows.Forms.DockStyle.Fill;
@@ -2996,7 +3002,6 @@
             // olvColumnContentTypeEShop
             // 
             this.olvColumnContentTypeEShop.AspectName = "ContentType";
-            this.olvColumnContentTypeEShop.DisplayIndex = 15;
             this.olvColumnContentTypeEShop.Text = "Content Type";
             // 
             // contextMenuEShopList

--- a/Switch Backup Manager/Form1.Designer.cs
+++ b/Switch Backup Manager/Form1.Designer.cs
@@ -237,6 +237,7 @@
             this.label4 = new System.Windows.Forms.Label();
             this.cbxFilterScene = new System.Windows.Forms.ComboBox();
             this.OLVSceneList = new BrightIdeasSoftware.ObjectListView();
+            this.olvColumnFound = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
             this.olvColumnTitleIDScene = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
             this.olvColumnGameNameScene = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
             this.sizeColumnROMSizeScene = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
@@ -2235,7 +2236,7 @@
             this.tabPage3.Location = new System.Drawing.Point(4, 22);
             this.tabPage3.Name = "tabPage3";
             this.tabPage3.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage3.Size = new System.Drawing.Size(1517, 490);
+            this.tabPage3.Size = new System.Drawing.Size(1519, 492);
             this.tabPage3.TabIndex = 2;
             this.tabPage3.Text = "Scene releases";
             this.tabPage3.UseVisualStyleBackColor = true;
@@ -2251,7 +2252,7 @@
             this.panel4.Dock = System.Windows.Forms.DockStyle.Fill;
             this.panel4.Location = new System.Drawing.Point(3, 3);
             this.panel4.Name = "panel4";
-            this.panel4.Size = new System.Drawing.Size(1511, 484);
+            this.panel4.Size = new System.Drawing.Size(1513, 486);
             this.panel4.TabIndex = 0;
             // 
             // btnClearFilterScene
@@ -2293,6 +2294,7 @@
             // 
             // OLVSceneList
             // 
+            this.OLVSceneList.AllColumns.Add(this.olvColumnFound);
             this.OLVSceneList.AllColumns.Add(this.olvColumnTitleIDScene);
             this.OLVSceneList.AllColumns.Add(this.olvColumnGameNameScene);
             this.OLVSceneList.AllColumns.Add(this.sizeColumnROMSizeScene);
@@ -2307,6 +2309,7 @@
             this.OLVSceneList.AllColumns.Add(this.olvColumnSceneID);
             this.OLVSceneList.CellEditUseWholeCell = false;
             this.OLVSceneList.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.olvColumnFound,
             this.olvColumnTitleIDScene,
             this.olvColumnGameNameScene,
             this.sizeColumnROMSizeScene,
@@ -2327,7 +2330,7 @@
             this.OLVSceneList.Location = new System.Drawing.Point(0, 24);
             this.OLVSceneList.Name = "OLVSceneList";
             this.OLVSceneList.ShowGroups = false;
-            this.OLVSceneList.Size = new System.Drawing.Size(1511, 460);
+            this.OLVSceneList.Size = new System.Drawing.Size(1513, 462);
             this.OLVSceneList.TabIndex = 6;
             this.OLVSceneList.UseCellFormatEvents = true;
             this.OLVSceneList.UseCompatibleStateImageBehavior = false;
@@ -2335,6 +2338,11 @@
             this.OLVSceneList.CellOver += new System.EventHandler<BrightIdeasSoftware.CellOverEventArgs>(this.OLVSceneList_CellOver);
             this.OLVSceneList.FormatCell += new System.EventHandler<BrightIdeasSoftware.FormatCellEventArgs>(this.OLVSceneList_FormatCell);
             this.OLVSceneList.ItemSelectionChanged += new System.Windows.Forms.ListViewItemSelectionChangedEventHandler(this.OLVSceneList_ItemSelectionChanged);
+            // 
+            // olvColumnFound
+            // 
+            this.olvColumnFound.AspectName = "Found";
+            this.olvColumnFound.Text = "Found";
             // 
             // olvColumnTitleIDScene
             // 
@@ -2345,14 +2353,12 @@
             // olvColumnGameNameScene
             // 
             this.olvColumnGameNameScene.AspectName = "GameName";
-            this.olvColumnGameNameScene.DisplayIndex = 2;
             this.olvColumnGameNameScene.Text = "Game title";
             this.olvColumnGameNameScene.Width = 600;
             // 
             // sizeColumnROMSizeScene
             // 
             this.sizeColumnROMSizeScene.AspectName = "ROMSizeBytes";
-            this.sizeColumnROMSizeScene.DisplayIndex = 3;
             this.sizeColumnROMSizeScene.Text = "Trimmed size";
             this.sizeColumnROMSizeScene.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             this.sizeColumnROMSizeScene.Width = 92;
@@ -2360,14 +2366,12 @@
             // olvColumnDeveloperScene
             // 
             this.olvColumnDeveloperScene.AspectName = "Developer";
-            this.olvColumnDeveloperScene.DisplayIndex = 4;
             this.olvColumnDeveloperScene.Text = "Developer";
             this.olvColumnDeveloperScene.Width = 163;
             // 
             // columnSceneRegionScene
             // 
             this.columnSceneRegionScene.AspectName = "Region";
-            this.columnSceneRegionScene.DisplayIndex = 5;
             this.columnSceneRegionScene.Text = "Region";
             this.columnSceneRegionScene.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
             this.columnSceneRegionScene.Width = 47;
@@ -2375,21 +2379,18 @@
             // olvColumnLanguagesScene
             // 
             this.olvColumnLanguagesScene.AspectName = "Languages";
-            this.olvColumnLanguagesScene.DisplayIndex = 6;
             this.olvColumnLanguagesScene.Text = "Languages";
             this.olvColumnLanguagesScene.Width = 116;
             // 
             // olvColumnGroupScene
             // 
             this.olvColumnGroupScene.AspectName = "Group";
-            this.olvColumnGroupScene.DisplayIndex = 7;
             this.olvColumnGroupScene.Text = "Release group";
             this.olvColumnGroupScene.Width = 94;
             // 
             // olvColumnCartSizeScene
             // 
             this.olvColumnCartSizeScene.AspectName = "CartSize";
-            this.olvColumnCartSizeScene.DisplayIndex = 8;
             this.olvColumnCartSizeScene.Text = "Cart size";
             this.olvColumnCartSizeScene.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             this.olvColumnCartSizeScene.Width = 74;
@@ -2397,7 +2398,6 @@
             // olvColumnSerialScene
             // 
             this.olvColumnSerialScene.AspectName = "Serial";
-            this.olvColumnSerialScene.DisplayIndex = 9;
             this.olvColumnSerialScene.Text = "Serial number";
             this.olvColumnSerialScene.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
             this.olvColumnSerialScene.Width = 83;
@@ -2405,7 +2405,6 @@
             // olvColumnFirmwareScene
             // 
             this.olvColumnFirmwareScene.AspectName = "Firmware";
-            this.olvColumnFirmwareScene.DisplayIndex = 10;
             this.olvColumnFirmwareScene.Text = "Firmware";
             this.olvColumnFirmwareScene.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
             this.olvColumnFirmwareScene.Width = 93;
@@ -2413,7 +2412,6 @@
             // olvColumnCardTypeScene
             // 
             this.olvColumnCardTypeScene.AspectName = "Cardtype";
-            this.olvColumnCardTypeScene.DisplayIndex = 11;
             this.olvColumnCardTypeScene.Text = "Card type";
             this.olvColumnCardTypeScene.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
             this.olvColumnCardTypeScene.Width = 57;
@@ -2421,7 +2419,6 @@
             // olvColumnSceneID
             // 
             this.olvColumnSceneID.AspectName = "IdScene";
-            this.olvColumnSceneID.DisplayIndex = 1;
             this.olvColumnSceneID.Text = "ID";
             this.olvColumnSceneID.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
             // 
@@ -2452,7 +2449,7 @@
             this.toolStripMenuItem85});
             this.menuStrip3.Location = new System.Drawing.Point(0, 0);
             this.menuStrip3.Name = "menuStrip3";
-            this.menuStrip3.Size = new System.Drawing.Size(1511, 24);
+            this.menuStrip3.Size = new System.Drawing.Size(1513, 24);
             this.menuStrip3.TabIndex = 5;
             this.menuStrip3.Text = "menuStrip3";
             // 
@@ -2835,7 +2832,7 @@
             this.tabPage4.Location = new System.Drawing.Point(4, 22);
             this.tabPage4.Name = "tabPage4";
             this.tabPage4.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage4.Size = new System.Drawing.Size(1519, 492);
+            this.tabPage4.Size = new System.Drawing.Size(1517, 490);
             this.tabPage4.TabIndex = 3;
             this.tabPage4.Text = "E-shop files";
             this.tabPage4.UseVisualStyleBackColor = true;
@@ -2846,7 +2843,7 @@
             this.panel10.Dock = System.Windows.Forms.DockStyle.Fill;
             this.panel10.Location = new System.Drawing.Point(3, 31);
             this.panel10.Name = "panel10";
-            this.panel10.Size = new System.Drawing.Size(1513, 458);
+            this.panel10.Size = new System.Drawing.Size(1511, 456);
             this.panel10.TabIndex = 11;
             // 
             // OLVEshop
@@ -2892,7 +2889,7 @@
             this.OLVEshop.Location = new System.Drawing.Point(0, 0);
             this.OLVEshop.Name = "OLVEshop";
             this.OLVEshop.ShowGroups = false;
-            this.OLVEshop.Size = new System.Drawing.Size(1513, 458);
+            this.OLVEshop.Size = new System.Drawing.Size(1511, 456);
             this.OLVEshop.TabIndex = 3;
             this.OLVEshop.UseCellFormatEvents = true;
             this.OLVEshop.UseCompatibleStateImageBehavior = false;
@@ -3123,7 +3120,7 @@
             this.panel11.Dock = System.Windows.Forms.DockStyle.Top;
             this.panel11.Location = new System.Drawing.Point(3, 3);
             this.panel11.Name = "panel11";
-            this.panel11.Size = new System.Drawing.Size(1513, 28);
+            this.panel11.Size = new System.Drawing.Size(1511, 28);
             this.panel11.TabIndex = 10;
             // 
             // panel13
@@ -3136,7 +3133,7 @@
             this.panel13.Controls.Add(this.label5);
             this.panel13.Controls.Add(this.cbxFilterEshop);
             this.panel13.Dock = System.Windows.Forms.DockStyle.Right;
-            this.panel13.Location = new System.Drawing.Point(800, 0);
+            this.panel13.Location = new System.Drawing.Point(798, 0);
             this.panel13.Name = "panel13";
             this.panel13.Size = new System.Drawing.Size(713, 28);
             this.panel13.TabIndex = 1;
@@ -4485,6 +4482,7 @@
         private System.Windows.Forms.CheckBox cbUpdates;
         private System.Windows.Forms.CheckBox cbDLC;
         private BrightIdeasSoftware.OLVColumn olvColumnContentTypeEShop;
+        private BrightIdeasSoftware.OLVColumn olvColumnFound;
     }
 }
 

--- a/Switch Backup Manager/Form1.cs
+++ b/Switch Backup Manager/Form1.cs
@@ -125,6 +125,8 @@ namespace Switch_Backup_Manager
             UpdateSceneReleasesList();
             UpdateLocalGamesList();
             UpdateLocalNSPGamesList();
+            UpdateSceneReleaseListFoundColumn();
+
             FilterEshopByContentType();
 
             try
@@ -540,6 +542,32 @@ namespace Switch_Backup_Manager
 
             SceneReleasesSelectedItems = new Dictionary<Tuple<string, string>, FileData>();
             SumarizeLocalGamesList("scene");
+        }
+
+        public void UpdateSceneReleaseListFoundColumn()
+        {
+            foreach (FileData release in OLVSceneList.Objects)
+            {
+                if (LocalFilesList.ContainsKey(new Tuple<string, string>(release.TitleID, release.Version)))
+                {
+                    release.Found = "xci";
+                    OLVSceneList.RefreshObject(release);
+                }
+
+                if (LocalNSPFilesList.ContainsKey(new Tuple<string, string>(release.TitleID, release.Version)))
+                {
+                    if (String.IsNullOrEmpty(release.Found))
+                    {
+                        release.Found = "nsp";
+                    }
+                    else
+                    {
+                        release.Found = "both";
+                    }
+                    OLVSceneList.RefreshObject(release);
+                }
+
+            }
         }
 
         public void UpdateSDCardList()
@@ -1919,6 +1947,7 @@ namespace Switch_Backup_Manager
             Util.UpdateNSWDB();
             Util.XML_NSWDB = XDocument.Load(@Util.NSWDB_FILE);
             UpdateSceneReleasesList();
+            UpdateSceneReleaseListFoundColumn();
             MessageBox.Show("Done.");
         }
 
@@ -1932,6 +1961,7 @@ namespace Switch_Backup_Manager
             Util.UpdateNSWDB();
             Util.XML_NSWDB = XDocument.Load(@Util.NSWDB_FILE);
             UpdateSceneReleasesList();
+            UpdateSceneReleaseListFoundColumn();
             MessageBox.Show("Done.");
         }
 

--- a/Switch Backup Manager/Form1.cs
+++ b/Switch Backup Manager/Form1.cs
@@ -1146,7 +1146,7 @@ namespace Switch_Backup_Manager
                     long size = 0;
                     foreach (ListViewItem item in selectedItems)
                     {
-                        titleID = item.Text;
+                        titleID = item.SubItems[9].Text;
                         version = Convert.ToString(((FileData)((OLVListItem)item).RowObject).Version);
                         FileData data = Util.GetFileData(titleID, version, SceneReleasesList);
                         SceneReleasesSelectedItems.Add(new Tuple<string, string>(titleID, version), data);

--- a/Switch Backup Manager/FormConfigs.cs
+++ b/Switch Backup Manager/FormConfigs.cs
@@ -65,6 +65,7 @@ namespace Switch_Backup_Manager
         public void WriteConfig()
         {
             Util.autoRenamingPattern = this.autoRenamingPattern;
+            Util.autoRenamingPatternNSP = this.autoRenamingPatternNSP;
             Util.ini.IniWriteValue("AutoRenaming", "pattern", this.autoRenamingPattern);
             Util.ini.IniWriteValue("AutoRenaming", "patternNSP", this.autoRenamingPatternNSP);
             int maxFileNameSize = 0;

--- a/Switch Backup Manager/FormConfigs.cs
+++ b/Switch Backup Manager/FormConfigs.cs
@@ -45,7 +45,7 @@ namespace Switch_Backup_Manager
             gameExample.ContentType = "Patch";
             gameExample.Version = "0";
 
-            gameExampleNSP = new FileData("C:\\Switch\\1-2-Switch [01000320000cc000][v0].nsp", "1-2-Switch [01000320000cc000][v0]", "1-2-Switch [01000320000cc000][v0].nsp", 
+            gameExampleNSP = new FileData("XCI", "C:\\Switch\\1-2-Switch [01000320000cc000][v0].nsp", "1-2-Switch [01000320000cc000][v0]", "1-2-Switch [01000320000cc000][v0].nsp", 
                 "1,38 GB", 1481339176, "1,38 GB", 1481339176, "01000320000CC000" , "01000320000CC000", "1-2-Switch", "Nintendo", "1.0.0", "No Prod. ID", "0.12.12.0", "e-shop", 
                 "0 (1.0.0-2.3.0)", new Dictionary<string, string> { { "American English", "cache\\icon_01000320000CC000_AmericanEnglish.bmp" }, { "Japanese", "cache\\icon_01000320000CC000_Japanese.bmp" } },
                 new List<string> { "American English", "Japanese" }, "en, ja", true, "", "", "0", "e-shop", "", false, "Download", 0, "Application", "0", true, "", "Nintendo", "Mar 03, 2017", 

--- a/Switch Backup Manager/Util.cs
+++ b/Switch Backup Manager/Util.cs
@@ -21,7 +21,7 @@ namespace Switch_Backup_Manager
 {
     internal static class Util
     {
-        public const string VERSION = "1.1.2";   //Actual application version
+        public const string VERSION = "1.1.4";   //Actual application version
         public const string MIN_DB_Version = "1.1.1"; //This is the minimum version of the DB that can work
 
         public const string INI_FILE = "sbm.ini";
@@ -1712,7 +1712,7 @@ namespace Switch_Backup_Manager
                     return data;
                 }
                 PFS0.PFS0_Entry[] array3;
-                array3 = new PFS0.PFS0_Entry[Math.Max(PFS0.PFS0_Headers[0].FileCount, 20)]; //Dump of TitleID 01009AA000FAA000 reports more than 10000000 files here, so it breaks the program. Standard is to have only 20 files
+                array3 = new PFS0.PFS0_Entry[Math.Max(PFS0.PFS0_Headers[0].FileCount, 150)]; //Dump of TitleID 01009AA000FAA000 reports more than 10000000 files here, so it breaks the program. We need to put some reasonable number here.
 
                 for (int m = 0; m < PFS0.PFS0_Headers[0].FileCount; m++)
                 {
@@ -1720,7 +1720,7 @@ namespace Switch_Backup_Manager
                     fileStream.Read(array2, 0, 24);
                     array3[m] = new PFS0.PFS0_Entry(array2);
 
-                    if (m == 19) //Dump of TitleID 01009AA000FAA000 reports more than 10000000 files here, so it breaks the program. Standard is to have only 20 files
+                    if (m == 149) //Dump of TitleID 01009AA000FAA000 reports more than 10000000 files here, so it breaks the program. We need to put some reasonable number here.
                     {
                         break;
                     }
@@ -1954,7 +1954,7 @@ namespace Switch_Backup_Manager
                         }
                     }
 
-                    if (n == 19) //Dump of TitleID 01009AA000FAA000 reports more than 10000000 files here, so it breaks the program. Standard is to have only 20 files
+                    if (n == 149) //Dump of TitleID 01009AA000FAA000 reports more than 10000000 files here, so it breaks the program. We need to put some reasonable number here.
                     {
                         break;
                     }
@@ -1986,7 +1986,7 @@ namespace Switch_Backup_Manager
                         break;
                     }
 
-                    if (n == 19) //Dump of TitleID 01009AA000FAA000 reports more than 10000000 files here, so it breaks the program. Standard is to have only 20 files
+                    if (n == 149) //Dump of TitleID 01009AA000FAA000 reports more than 10000000 files here, so it breaks the program. We need to put some reasonable number here.
                     {
                         break;
                     }


### PR DESCRIPTION
This does fix logic as well as making sure the scene info is used for NSP files as well.  Not 100% sure that all the fields available are being used, but its way better, and much more usable.