### PR TITLE
fallback if MasterKey revision not supported by hactool

### DIFF
--- a/Switch Backup Manager/Util.cs
+++ b/Switch Backup Manager/Util.cs
@@ -1545,9 +1545,9 @@ namespace Switch_Backup_Manager
                 case 4:
                     return "MasterKey3 (4.0.0-4.1.0)";
                 case 5:
-                    return "MasterKey4 (5.0.0+)";
+                    return "MasterKey4 (5.0.0-5.1.0)";
                 case 6:
-                    return "MasterKey5 (?)";
+                    return "MasterKey5 (6.0.0)";
                 case 7:
                     return "MasterKey6 (?)";
                 case 8:
@@ -2364,7 +2364,16 @@ namespace Switch_Backup_Manager
                     }
                     else if (strArray[0] == "Master Key Revision")
                     {
-                        data.MasterKeyRevision = strArray[1].Trim();
+                        string MasterKey = strArray[1].Trim();
+                        if (MasterKey.Contains("Unknown"))
+                        {
+                            int keyblob;
+                            if (int.TryParse(new string(MasterKey.TakeWhile(Char.IsDigit).ToArray()), out keyblob))
+                            {
+                                MasterKey = GetMkey((byte) (keyblob + 1));
+                            }
+                        }
+                        data.MasterKeyRevision = MasterKey;
                         break;
                     }
                 }

--- a/Switch Backup Manager/Util.cs
+++ b/Switch Backup Manager/Util.cs
@@ -1547,7 +1547,7 @@ namespace Switch_Backup_Manager
                 case 5:
                     return "MasterKey4 (5.0.0-5.1.0)";
                 case 6:
-                    return "MasterKey5 (6.0.0)";
+                    return "MasterKey5 (6.0.0-6.0.1)";
                 case 7:
                     return "MasterKey6 (?)";
                 case 8:

--- a/Switch Backup Manager/Util.cs
+++ b/Switch Backup Manager/Util.cs
@@ -2370,7 +2370,7 @@ namespace Switch_Backup_Manager
                             int keyblob;
                             if (int.TryParse(new string(MasterKey.TakeWhile(Char.IsDigit).ToArray()), out keyblob))
                             {
-                                MasterKey = GetMkey((byte) (keyblob + 1));
+                                MasterKey = GetMkey((byte)(keyblob + 1)).Replace("MasterKey", "");
                             }
                         }
                         data.MasterKeyRevision = MasterKey;
@@ -2613,7 +2613,7 @@ namespace Switch_Backup_Manager
                 result.TitleID = "0" + NCA.NCA_Headers[0].TitleID.ToString("X");
                 result.TitleIDBaseGame = result.TitleID;
                 result.SDKVersion = $"{NCA.NCA_Headers[0].SDKVersion4}.{NCA.NCA_Headers[0].SDKVersion3}.{NCA.NCA_Headers[0].SDKVersion2}.{NCA.NCA_Headers[0].SDKVersion1}";
-                result.MasterKeyRevision = Util.GetMkey(NCA.NCA_Headers[0].MasterKeyRev);
+                result.MasterKeyRevision = Util.GetMkey(NCA.NCA_Headers[0].MasterKeyRev).Replace("MasterKey", "");
 
                 //Extra Info Is Got Here
                 if (getMKey())


### PR DESCRIPTION
recently it occurs to me that MasterKey revision info is taken directly from hactool, so there's a chance that user is using an old hactool that doesn't handle newer MasterKey revision
for example, MasterKey4 is only supported on hactool 1.2.0 while MasterKey5 is not handled as of now

so I'm thinking to add a fallback implementation where if hactool returns **Unknown** for MasterKey firmware version, we handle it internally so we don't have to rely completely on hactool