### PR TITLE
fix Form1.Designer.cs

### DIFF
--- a/Switch Backup Manager/Form1.Designer.cs
+++ b/Switch Backup Manager/Form1.Designer.cs
@@ -463,6 +463,7 @@
             this.backgroundWorkerScanNewFiles = new System.ComponentModel.BackgroundWorker();
             this.backgroundWorkerUpdateFiles = new System.ComponentModel.BackgroundWorker();
             this.backgroundWorkerScrapExtraInfo = new System.ComponentModel.BackgroundWorker();
+            this.backgroundWorkerUpdateVersionList = new System.ComponentModel.BackgroundWorker();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
@@ -527,6 +528,7 @@
             this.splitContainer1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.splitContainer1.Location = new System.Drawing.Point(0, 0);
+            this.splitContainer1.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.splitContainer1.Name = "splitContainer1";
             // 
             // splitContainer1.Panel1
@@ -539,9 +541,9 @@
             // 
             this.splitContainer1.Panel2.Controls.Add(this.splitContainer2);
             this.splitContainer1.Panel2MinSize = 800;
-            this.splitContainer1.Size = new System.Drawing.Size(1880, 690);
-            this.splitContainer1.SplitterDistance = 350;
-            this.splitContainer1.SplitterWidth = 1;
+            this.splitContainer1.Size = new System.Drawing.Size(2820, 1255);
+            this.splitContainer1.SplitterDistance = 525;
+            this.splitContainer1.SplitterWidth = 2;
             this.splitContainer1.TabIndex = 0;
             // 
             // panelGameExtraInfo
@@ -557,17 +559,19 @@
             this.panelGameExtraInfo.Controls.Add(this.lblNumberOfPlayers);
             this.panelGameExtraInfo.Controls.Add(this.lblReleaseDate);
             this.panelGameExtraInfo.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panelGameExtraInfo.Location = new System.Drawing.Point(0, 369);
+            this.panelGameExtraInfo.Location = new System.Drawing.Point(0, 568);
+            this.panelGameExtraInfo.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.panelGameExtraInfo.Name = "panelGameExtraInfo";
-            this.panelGameExtraInfo.Size = new System.Drawing.Size(348, 319);
+            this.panelGameExtraInfo.Size = new System.Drawing.Size(523, 685);
             this.panelGameExtraInfo.TabIndex = 2;
             this.panelGameExtraInfo.Visible = false;
             // 
             // lnkInfo
             // 
-            this.lnkInfo.Location = new System.Drawing.Point(10, 218);
+            this.lnkInfo.Location = new System.Drawing.Point(15, 335);
+            this.lnkInfo.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lnkInfo.Name = "lnkInfo";
-            this.lnkInfo.Size = new System.Drawing.Size(328, 13);
+            this.lnkInfo.Size = new System.Drawing.Size(492, 20);
             this.lnkInfo.TabIndex = 29;
             this.lnkInfo.TabStop = true;
             this.lnkInfo.Text = "E-shop homepage";
@@ -578,9 +582,10 @@
             // lblPublisher
             // 
             this.lblPublisher.AutoSize = true;
-            this.lblPublisher.Location = new System.Drawing.Point(104, 292);
+            this.lblPublisher.Location = new System.Drawing.Point(156, 449);
+            this.lblPublisher.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblPublisher.Name = "lblPublisher";
-            this.lblPublisher.Size = new System.Drawing.Size(41, 13);
+            this.lblPublisher.Size = new System.Drawing.Size(60, 20);
             this.lblPublisher.TabIndex = 14;
             this.lblPublisher.Text = "label10";
             // 
@@ -588,9 +593,10 @@
             // 
             this.label9.AutoSize = true;
             this.label9.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label9.Location = new System.Drawing.Point(10, 317);
+            this.label9.Location = new System.Drawing.Point(15, 488);
+            this.label9.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(61, 13);
+            this.label9.Size = new System.Drawing.Size(90, 20);
             this.label9.TabIndex = 13;
             this.label9.Text = "Category:";
             // 
@@ -598,9 +604,10 @@
             // 
             this.label8.AutoSize = true;
             this.label8.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label8.Location = new System.Drawing.Point(10, 292);
+            this.label8.Location = new System.Drawing.Point(15, 449);
+            this.label8.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(63, 13);
+            this.label8.Size = new System.Drawing.Size(94, 20);
             this.label8.TabIndex = 12;
             this.label8.Text = "Publisher:";
             // 
@@ -608,9 +615,10 @@
             // 
             this.label7.AutoSize = true;
             this.label7.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label7.Location = new System.Drawing.Point(10, 267);
+            this.label7.Location = new System.Drawing.Point(15, 411);
+            this.label7.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(85, 13);
+            this.label7.Size = new System.Drawing.Size(127, 20);
             this.label7.TabIndex = 11;
             this.label7.Text = "N° of Players:";
             // 
@@ -618,9 +626,10 @@
             // 
             this.label6.AutoSize = true;
             this.label6.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label6.Location = new System.Drawing.Point(10, 242);
+            this.label6.Location = new System.Drawing.Point(15, 372);
+            this.label6.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(88, 13);
+            this.label6.Size = new System.Drawing.Size(129, 20);
             this.label6.TabIndex = 10;
             this.label6.Text = "Release Date:";
             // 
@@ -629,9 +638,10 @@
             this.pnlGameDescription.Controls.Add(this.richTextBoxGameDescription);
             this.pnlGameDescription.Dock = System.Windows.Forms.DockStyle.Top;
             this.pnlGameDescription.Location = new System.Drawing.Point(0, 0);
+            this.pnlGameDescription.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.pnlGameDescription.Name = "pnlGameDescription";
-            this.pnlGameDescription.Padding = new System.Windows.Forms.Padding(10, 10, 10, 10);
-            this.pnlGameDescription.Size = new System.Drawing.Size(348, 208);
+            this.pnlGameDescription.Padding = new System.Windows.Forms.Padding(15);
+            this.pnlGameDescription.Size = new System.Drawing.Size(523, 320);
             this.pnlGameDescription.TabIndex = 9;
             // 
             // richTextBoxGameDescription
@@ -640,37 +650,41 @@
             this.richTextBoxGameDescription.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.richTextBoxGameDescription.Dock = System.Windows.Forms.DockStyle.Fill;
             this.richTextBoxGameDescription.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.richTextBoxGameDescription.Location = new System.Drawing.Point(10, 10);
+            this.richTextBoxGameDescription.Location = new System.Drawing.Point(15, 15);
+            this.richTextBoxGameDescription.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.richTextBoxGameDescription.Name = "richTextBoxGameDescription";
             this.richTextBoxGameDescription.ReadOnly = true;
-            this.richTextBoxGameDescription.Size = new System.Drawing.Size(328, 188);
+            this.richTextBoxGameDescription.Size = new System.Drawing.Size(493, 290);
             this.richTextBoxGameDescription.TabIndex = 9;
             this.richTextBoxGameDescription.Text = "";
             // 
             // lblCategory
             // 
             this.lblCategory.AutoSize = true;
-            this.lblCategory.Location = new System.Drawing.Point(104, 317);
+            this.lblCategory.Location = new System.Drawing.Point(156, 488);
+            this.lblCategory.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblCategory.Name = "lblCategory";
-            this.lblCategory.Size = new System.Drawing.Size(35, 13);
+            this.lblCategory.Size = new System.Drawing.Size(51, 20);
             this.lblCategory.TabIndex = 7;
             this.lblCategory.Text = "label6";
             // 
             // lblNumberOfPlayers
             // 
             this.lblNumberOfPlayers.AutoSize = true;
-            this.lblNumberOfPlayers.Location = new System.Drawing.Point(104, 267);
+            this.lblNumberOfPlayers.Location = new System.Drawing.Point(156, 411);
+            this.lblNumberOfPlayers.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblNumberOfPlayers.Name = "lblNumberOfPlayers";
-            this.lblNumberOfPlayers.Size = new System.Drawing.Size(35, 13);
+            this.lblNumberOfPlayers.Size = new System.Drawing.Size(51, 20);
             this.lblNumberOfPlayers.TabIndex = 6;
             this.lblNumberOfPlayers.Text = "label6";
             // 
             // lblReleaseDate
             // 
             this.lblReleaseDate.AutoSize = true;
-            this.lblReleaseDate.Location = new System.Drawing.Point(104, 242);
+            this.lblReleaseDate.Location = new System.Drawing.Point(156, 372);
+            this.lblReleaseDate.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblReleaseDate.Name = "lblReleaseDate";
-            this.lblReleaseDate.Size = new System.Drawing.Size(35, 13);
+            this.lblReleaseDate.Size = new System.Drawing.Size(51, 20);
             this.lblReleaseDate.TabIndex = 5;
             this.lblReleaseDate.Text = "label6";
             // 
@@ -679,21 +693,21 @@
             this.panel3.Controls.Add(this.PB_GameIcon);
             this.panel3.Dock = System.Windows.Forms.DockStyle.Top;
             this.panel3.Location = new System.Drawing.Point(0, 0);
-            this.panel3.Margin = new System.Windows.Forms.Padding(10, 10, 10, 10);
+            this.panel3.Margin = new System.Windows.Forms.Padding(15);
             this.panel3.Name = "panel3";
-            this.panel3.Padding = new System.Windows.Forms.Padding(10, 10, 10, 10);
-            this.panel3.Size = new System.Drawing.Size(348, 369);
+            this.panel3.Padding = new System.Windows.Forms.Padding(15);
+            this.panel3.Size = new System.Drawing.Size(523, 568);
             this.panel3.TabIndex = 1;
             // 
             // PB_GameIcon
             // 
             this.PB_GameIcon.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
             this.PB_GameIcon.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.PB_GameIcon.Location = new System.Drawing.Point(10, 10);
-            this.PB_GameIcon.Margin = new System.Windows.Forms.Padding(20, 20, 20, 20);
+            this.PB_GameIcon.Location = new System.Drawing.Point(15, 15);
+            this.PB_GameIcon.Margin = new System.Windows.Forms.Padding(30, 31, 30, 31);
             this.PB_GameIcon.Name = "PB_GameIcon";
-            this.PB_GameIcon.Padding = new System.Windows.Forms.Padding(10, 10, 10, 10);
-            this.PB_GameIcon.Size = new System.Drawing.Size(328, 349);
+            this.PB_GameIcon.Padding = new System.Windows.Forms.Padding(15);
+            this.PB_GameIcon.Size = new System.Drawing.Size(493, 538);
             this.PB_GameIcon.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
             this.PB_GameIcon.TabIndex = 28;
             this.PB_GameIcon.TabStop = false;
@@ -703,6 +717,7 @@
             this.splitContainer2.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.splitContainer2.Dock = System.Windows.Forms.DockStyle.Fill;
             this.splitContainer2.Location = new System.Drawing.Point(0, 0);
+            this.splitContainer2.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.splitContainer2.Name = "splitContainer2";
             this.splitContainer2.Orientation = System.Windows.Forms.Orientation.Horizontal;
             // 
@@ -716,9 +731,9 @@
             // 
             this.splitContainer2.Panel2.Controls.Add(this.panelEditTitle);
             this.splitContainer2.Panel2MinSize = 220;
-            this.splitContainer2.Size = new System.Drawing.Size(1529, 690);
-            this.splitContainer2.SplitterDistance = 469;
-            this.splitContainer2.SplitterWidth = 1;
+            this.splitContainer2.Size = new System.Drawing.Size(2293, 1255);
+            this.splitContainer2.SplitterDistance = 873;
+            this.splitContainer2.SplitterWidth = 2;
             this.splitContainer2.TabIndex = 0;
             // 
             // tabControl1
@@ -729,10 +744,11 @@
             this.tabControl1.Controls.Add(this.tabPage4);
             this.tabControl1.Controls.Add(this.tabPage5);
             this.tabControl1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tabControl1.Location = new System.Drawing.Point(0, 24);
+            this.tabControl1.Location = new System.Drawing.Point(0, 35);
+            this.tabControl1.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;
-            this.tabControl1.Size = new System.Drawing.Size(1527, 394);
+            this.tabControl1.Size = new System.Drawing.Size(2291, 787);
             this.tabControl1.TabIndex = 1;
             this.tabControl1.SelectedIndexChanged += new System.EventHandler(this.tabControl1_SelectedIndexChanged);
             this.tabControl1.TabIndexChanged += new System.EventHandler(this.tabControl1_TabIndexChanged);
@@ -741,10 +757,11 @@
             // 
             this.tabPage1.Controls.Add(this.panel2);
             this.tabPage1.Controls.Add(this.panel1);
-            this.tabPage1.Location = new System.Drawing.Point(4, 22);
+            this.tabPage1.Location = new System.Drawing.Point(4, 29);
+            this.tabPage1.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.tabPage1.Name = "tabPage1";
-            this.tabPage1.Padding = new System.Windows.Forms.Padding(3, 3, 3, 3);
-            this.tabPage1.Size = new System.Drawing.Size(1519, 368);
+            this.tabPage1.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.tabPage1.Size = new System.Drawing.Size(2283, 754);
             this.tabPage1.TabIndex = 0;
             this.tabPage1.Text = "Local files";
             this.tabPage1.UseVisualStyleBackColor = true;
@@ -753,9 +770,10 @@
             // 
             this.panel2.Controls.Add(this.OLVLocalFiles);
             this.panel2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panel2.Location = new System.Drawing.Point(3, 31);
+            this.panel2.Location = new System.Drawing.Point(4, 48);
+            this.panel2.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.panel2.Name = "panel2";
-            this.panel2.Size = new System.Drawing.Size(1513, 334);
+            this.panel2.Size = new System.Drawing.Size(2275, 701);
             this.panel2.TabIndex = 1;
             // 
             // OLVLocalFiles
@@ -812,9 +830,10 @@
             this.OLVLocalFiles.FullRowSelect = true;
             this.OLVLocalFiles.GridLines = true;
             this.OLVLocalFiles.Location = new System.Drawing.Point(0, 0);
+            this.OLVLocalFiles.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.OLVLocalFiles.Name = "OLVLocalFiles";
             this.OLVLocalFiles.ShowGroups = false;
-            this.OLVLocalFiles.Size = new System.Drawing.Size(1513, 334);
+            this.OLVLocalFiles.Size = new System.Drawing.Size(2275, 701);
             this.OLVLocalFiles.TabIndex = 1;
             this.OLVLocalFiles.UseCellFormatEvents = true;
             this.OLVLocalFiles.UseCompatibleStateImageBehavior = false;
@@ -983,39 +1002,39 @@
             this.toolStripMenuItem97LocalFiles,
             this.deleteSelectedFileserasesFromDiskToolStripMenuItemLocalFiles});
             this.contextMenuLocalList.Name = "contextMenuLocalList";
-            this.contextMenuLocalList.Size = new System.Drawing.Size(277, 204);
+            this.contextMenuLocalList.Size = new System.Drawing.Size(390, 268);
             this.contextMenuLocalList.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenuLocalList_Opening);
             // 
             // showInExplorerToolStripMenuItem
             // 
             this.showInExplorerToolStripMenuItem.Name = "showInExplorerToolStripMenuItem";
-            this.showInExplorerToolStripMenuItem.Size = new System.Drawing.Size(276, 22);
+            this.showInExplorerToolStripMenuItem.Size = new System.Drawing.Size(389, 30);
             this.showInExplorerToolStripMenuItem.Text = "Show in explorer";
             this.showInExplorerToolStripMenuItem.Click += new System.EventHandler(this.showInExplorerToolStripMenuItem_Click);
             // 
             // toolStripMenuItem20
             // 
             this.toolStripMenuItem20.Name = "toolStripMenuItem20";
-            this.toolStripMenuItem20.Size = new System.Drawing.Size(273, 6);
+            this.toolStripMenuItem20.Size = new System.Drawing.Size(386, 6);
             // 
             // trimFilesToolStripMenuItem
             // 
             this.trimFilesToolStripMenuItem.Name = "trimFilesToolStripMenuItem";
-            this.trimFilesToolStripMenuItem.Size = new System.Drawing.Size(276, 22);
+            this.trimFilesToolStripMenuItem.Size = new System.Drawing.Size(389, 30);
             this.trimFilesToolStripMenuItem.Text = "Trim files";
             this.trimFilesToolStripMenuItem.Click += new System.EventHandler(this.trimFilesToolStripMenuItem_Click);
             // 
             // autoRenameFilesToolStripMenuItem
             // 
             this.autoRenameFilesToolStripMenuItem.Name = "autoRenameFilesToolStripMenuItem";
-            this.autoRenameFilesToolStripMenuItem.Size = new System.Drawing.Size(276, 22);
+            this.autoRenameFilesToolStripMenuItem.Size = new System.Drawing.Size(389, 30);
             this.autoRenameFilesToolStripMenuItem.Text = "Auto rename files";
             this.autoRenameFilesToolStripMenuItem.Click += new System.EventHandler(this.autoRenameFilesToolStripMenuItem_Click);
             // 
             // toolStripMenuItem96
             // 
             this.toolStripMenuItem96.Name = "toolStripMenuItem96";
-            this.toolStripMenuItem96.Size = new System.Drawing.Size(273, 6);
+            this.toolStripMenuItem96.Size = new System.Drawing.Size(386, 6);
             // 
             // copyFilesToolStripMenuItem2
             // 
@@ -1023,20 +1042,20 @@
             this.sDCardToolStripMenuItem2,
             this.folderToolStripMenuItem2});
             this.copyFilesToolStripMenuItem2.Name = "copyFilesToolStripMenuItem2";
-            this.copyFilesToolStripMenuItem2.Size = new System.Drawing.Size(276, 22);
+            this.copyFilesToolStripMenuItem2.Size = new System.Drawing.Size(389, 30);
             this.copyFilesToolStripMenuItem2.Text = "Copy files to";
             // 
             // sDCardToolStripMenuItem2
             // 
             this.sDCardToolStripMenuItem2.Name = "sDCardToolStripMenuItem2";
-            this.sDCardToolStripMenuItem2.Size = new System.Drawing.Size(116, 22);
+            this.sDCardToolStripMenuItem2.Size = new System.Drawing.Size(158, 30);
             this.sDCardToolStripMenuItem2.Text = "SD card";
             this.sDCardToolStripMenuItem2.Click += new System.EventHandler(this.sDCardToolStripMenuItem2_Click);
             // 
             // folderToolStripMenuItem2
             // 
             this.folderToolStripMenuItem2.Name = "folderToolStripMenuItem2";
-            this.folderToolStripMenuItem2.Size = new System.Drawing.Size(116, 22);
+            this.folderToolStripMenuItem2.Size = new System.Drawing.Size(158, 30);
             this.folderToolStripMenuItem2.Text = "Folder...";
             this.folderToolStripMenuItem2.Click += new System.EventHandler(this.folderToolStripMenuItem2_Click);
             // 
@@ -1046,51 +1065,51 @@
             this.sDCardToolStripMenuItem3,
             this.folderToolStripMenuItem3});
             this.moveFilesToToolStripMenuItem.Name = "moveFilesToToolStripMenuItem";
-            this.moveFilesToToolStripMenuItem.Size = new System.Drawing.Size(276, 22);
+            this.moveFilesToToolStripMenuItem.Size = new System.Drawing.Size(389, 30);
             this.moveFilesToToolStripMenuItem.Text = "Move files to";
             // 
             // sDCardToolStripMenuItem3
             // 
             this.sDCardToolStripMenuItem3.Name = "sDCardToolStripMenuItem3";
-            this.sDCardToolStripMenuItem3.Size = new System.Drawing.Size(116, 22);
+            this.sDCardToolStripMenuItem3.Size = new System.Drawing.Size(158, 30);
             this.sDCardToolStripMenuItem3.Text = "SD card";
             this.sDCardToolStripMenuItem3.Click += new System.EventHandler(this.sDCardToolStripMenuItem3_Click);
             // 
             // folderToolStripMenuItem3
             // 
             this.folderToolStripMenuItem3.Name = "folderToolStripMenuItem3";
-            this.folderToolStripMenuItem3.Size = new System.Drawing.Size(116, 22);
+            this.folderToolStripMenuItem3.Size = new System.Drawing.Size(158, 30);
             this.folderToolStripMenuItem3.Text = "Folder...";
             this.folderToolStripMenuItem3.Click += new System.EventHandler(this.folderToolStripMenuItem3_Click);
             // 
             // toolStripMenuItem68
             // 
             this.toolStripMenuItem68.Name = "toolStripMenuItem68";
-            this.toolStripMenuItem68.Size = new System.Drawing.Size(273, 6);
+            this.toolStripMenuItem68.Size = new System.Drawing.Size(386, 6);
             // 
             // copyInfoToClipboardToolStripMenuItem1
             // 
             this.copyInfoToClipboardToolStripMenuItem1.Name = "copyInfoToClipboardToolStripMenuItem1";
-            this.copyInfoToClipboardToolStripMenuItem1.Size = new System.Drawing.Size(276, 22);
+            this.copyInfoToClipboardToolStripMenuItem1.Size = new System.Drawing.Size(389, 30);
             this.copyInfoToClipboardToolStripMenuItem1.Text = "Copy info to clipboard";
             this.copyInfoToClipboardToolStripMenuItem1.Click += new System.EventHandler(this.copyInfoToClipboardToolStripMenuItem1_Click);
             // 
             // updateGameInfoFromWebToolStripMenuItem
             // 
             this.updateGameInfoFromWebToolStripMenuItem.Name = "updateGameInfoFromWebToolStripMenuItem";
-            this.updateGameInfoFromWebToolStripMenuItem.Size = new System.Drawing.Size(276, 22);
+            this.updateGameInfoFromWebToolStripMenuItem.Size = new System.Drawing.Size(389, 30);
             this.updateGameInfoFromWebToolStripMenuItem.Text = "Update game info from Web";
             this.updateGameInfoFromWebToolStripMenuItem.Click += new System.EventHandler(this.updateGameInfoFromWebToolStripMenuItem_Click);
             // 
             // toolStripMenuItem97LocalFiles
             // 
             this.toolStripMenuItem97LocalFiles.Name = "toolStripMenuItem97LocalFiles";
-            this.toolStripMenuItem97LocalFiles.Size = new System.Drawing.Size(273, 6);
+            this.toolStripMenuItem97LocalFiles.Size = new System.Drawing.Size(386, 6);
             // 
             // deleteSelectedFileserasesFromDiskToolStripMenuItemLocalFiles
             // 
             this.deleteSelectedFileserasesFromDiskToolStripMenuItemLocalFiles.Name = "deleteSelectedFileserasesFromDiskToolStripMenuItemLocalFiles";
-            this.deleteSelectedFileserasesFromDiskToolStripMenuItemLocalFiles.Size = new System.Drawing.Size(276, 22);
+            this.deleteSelectedFileserasesFromDiskToolStripMenuItemLocalFiles.Size = new System.Drawing.Size(389, 30);
             this.deleteSelectedFileserasesFromDiskToolStripMenuItemLocalFiles.Text = "Delete selected files (erases from disk!)";
             this.deleteSelectedFileserasesFromDiskToolStripMenuItemLocalFiles.Click += new System.EventHandler(this.deleteSelectedFileserasesFromDiskToolStripMenuItemLocalFiles_Click);
             // 
@@ -1099,9 +1118,10 @@
             this.panel1.Controls.Add(this.panel9);
             this.panel1.Controls.Add(this.panel8);
             this.panel1.Dock = System.Windows.Forms.DockStyle.Top;
-            this.panel1.Location = new System.Drawing.Point(3, 3);
+            this.panel1.Location = new System.Drawing.Point(4, 5);
+            this.panel1.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(1513, 28);
+            this.panel1.Size = new System.Drawing.Size(2275, 43);
             this.panel1.TabIndex = 0;
             // 
             // panel9
@@ -1111,16 +1131,18 @@
             this.panel9.Controls.Add(this.label2);
             this.panel9.Controls.Add(this.cbxFilterLocal);
             this.panel9.Dock = System.Windows.Forms.DockStyle.Right;
-            this.panel9.Location = new System.Drawing.Point(755, 0);
+            this.panel9.Location = new System.Drawing.Point(1138, 0);
+            this.panel9.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.panel9.Name = "panel9";
-            this.panel9.Size = new System.Drawing.Size(758, 28);
+            this.panel9.Size = new System.Drawing.Size(1137, 43);
             this.panel9.TabIndex = 6;
             // 
             // btnClearFilterLocal
             // 
-            this.btnClearFilterLocal.Location = new System.Drawing.Point(679, 2);
+            this.btnClearFilterLocal.Location = new System.Drawing.Point(1018, 3);
+            this.btnClearFilterLocal.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.btnClearFilterLocal.Name = "btnClearFilterLocal";
-            this.btnClearFilterLocal.Size = new System.Drawing.Size(75, 23);
+            this.btnClearFilterLocal.Size = new System.Drawing.Size(112, 35);
             this.btnClearFilterLocal.TabIndex = 8;
             this.btnClearFilterLocal.Text = "Clear";
             this.btnClearFilterLocal.UseVisualStyleBackColor = true;
@@ -1128,9 +1150,10 @@
             // 
             // textBoxFilterLocal
             // 
-            this.textBoxFilterLocal.Location = new System.Drawing.Point(404, 4);
+            this.textBoxFilterLocal.Location = new System.Drawing.Point(606, 6);
+            this.textBoxFilterLocal.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.textBoxFilterLocal.Name = "textBoxFilterLocal";
-            this.textBoxFilterLocal.Size = new System.Drawing.Size(268, 20);
+            this.textBoxFilterLocal.Size = new System.Drawing.Size(400, 26);
             this.textBoxFilterLocal.TabIndex = 7;
             this.textBoxFilterLocal.TextChanged += new System.EventHandler(this.textBoxFilterLocal_TextChanged);
             // 
@@ -1138,9 +1161,10 @@
             // 
             this.label2.AutoSize = true;
             this.label2.BackColor = System.Drawing.SystemColors.Window;
-            this.label2.Location = new System.Drawing.Point(260, 7);
+            this.label2.Location = new System.Drawing.Point(390, 11);
+            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(32, 13);
+            this.label2.Size = new System.Drawing.Size(48, 20);
             this.label2.TabIndex = 6;
             this.label2.Text = "Filter:";
             // 
@@ -1148,9 +1172,10 @@
             // 
             this.cbxFilterLocal.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cbxFilterLocal.FormattingEnabled = true;
-            this.cbxFilterLocal.Location = new System.Drawing.Point(295, 3);
+            this.cbxFilterLocal.Location = new System.Drawing.Point(442, 5);
+            this.cbxFilterLocal.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.cbxFilterLocal.Name = "cbxFilterLocal";
-            this.cbxFilterLocal.Size = new System.Drawing.Size(102, 21);
+            this.cbxFilterLocal.Size = new System.Drawing.Size(151, 28);
             this.cbxFilterLocal.TabIndex = 5;
             this.cbxFilterLocal.SelectedIndexChanged += new System.EventHandler(this.cbxFilterLocal_SelectedIndexChanged);
             // 
@@ -1159,8 +1184,9 @@
             this.panel8.Controls.Add(this.menuLocalFiles);
             this.panel8.Dock = System.Windows.Forms.DockStyle.Left;
             this.panel8.Location = new System.Drawing.Point(0, 0);
+            this.panel8.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.panel8.Name = "panel8";
-            this.panel8.Size = new System.Drawing.Size(752, 28);
+            this.panel8.Size = new System.Drawing.Size(1128, 43);
             this.panel8.TabIndex = 5;
             // 
             // menuLocalFiles
@@ -1176,7 +1202,8 @@
             this.toolsToolStripMenuItem});
             this.menuLocalFiles.Location = new System.Drawing.Point(0, 0);
             this.menuLocalFiles.Name = "menuLocalFiles";
-            this.menuLocalFiles.Size = new System.Drawing.Size(752, 24);
+            this.menuLocalFiles.Padding = new System.Windows.Forms.Padding(9, 3, 0, 3);
+            this.menuLocalFiles.Size = new System.Drawing.Size(1128, 35);
             this.menuLocalFiles.TabIndex = 1;
             this.menuLocalFiles.Text = "menuStrip1";
             // 
@@ -1186,20 +1213,20 @@
             this.filesToolStripMenuItem,
             this.folderToolStripMenuItem});
             this.addToolStripMenuItem.Name = "addToolStripMenuItem";
-            this.addToolStripMenuItem.Size = new System.Drawing.Size(41, 20);
+            this.addToolStripMenuItem.Size = new System.Drawing.Size(58, 29);
             this.addToolStripMenuItem.Text = "&Add";
             // 
             // filesToolStripMenuItem
             // 
             this.filesToolStripMenuItem.Name = "filesToolStripMenuItem";
-            this.filesToolStripMenuItem.Size = new System.Drawing.Size(116, 22);
+            this.filesToolStripMenuItem.Size = new System.Drawing.Size(158, 30);
             this.filesToolStripMenuItem.Text = "Files...";
             this.filesToolStripMenuItem.Click += new System.EventHandler(this.filesToolStripMenuItem_Click);
             // 
             // folderToolStripMenuItem
             // 
             this.folderToolStripMenuItem.Name = "folderToolStripMenuItem";
-            this.folderToolStripMenuItem.Size = new System.Drawing.Size(116, 22);
+            this.folderToolStripMenuItem.Size = new System.Drawing.Size(158, 30);
             this.folderToolStripMenuItem.Text = "Folder...";
             this.folderToolStripMenuItem.Click += new System.EventHandler(this.folderToolStripMenuItem_Click);
             // 
@@ -1214,34 +1241,34 @@
             this.sceneReleasesToolStripMenuItem,
             this.eshopReleasesToolStripMenuItem});
             this.selectToolStripMenuItem.Name = "selectToolStripMenuItem";
-            this.selectToolStripMenuItem.Size = new System.Drawing.Size(50, 20);
+            this.selectToolStripMenuItem.Size = new System.Drawing.Size(70, 29);
             this.selectToolStripMenuItem.Text = "&Select";
             // 
             // allToolStripMenuItem
             // 
             this.allToolStripMenuItem.Name = "allToolStripMenuItem";
-            this.allToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
+            this.allToolStripMenuItem.Size = new System.Drawing.Size(219, 30);
             this.allToolStripMenuItem.Text = "All";
             this.allToolStripMenuItem.Click += new System.EventHandler(this.allToolStripMenuItem_Click);
             // 
             // noneToolStripMenuItem
             // 
             this.noneToolStripMenuItem.Name = "noneToolStripMenuItem";
-            this.noneToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
+            this.noneToolStripMenuItem.Size = new System.Drawing.Size(219, 30);
             this.noneToolStripMenuItem.Text = "None";
             this.noneToolStripMenuItem.Click += new System.EventHandler(this.noneToolStripMenuItem_Click);
             // 
             // invertSelectionToolStripMenuItem
             // 
             this.invertSelectionToolStripMenuItem.Name = "invertSelectionToolStripMenuItem";
-            this.invertSelectionToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
+            this.invertSelectionToolStripMenuItem.Size = new System.Drawing.Size(219, 30);
             this.invertSelectionToolStripMenuItem.Text = "Invert selection";
             this.invertSelectionToolStripMenuItem.Click += new System.EventHandler(this.invertSelectionToolStripMenuItem_Click);
             // 
             // toolStripMenuItem1
             // 
             this.toolStripMenuItem1.Name = "toolStripMenuItem1";
-            this.toolStripMenuItem1.Size = new System.Drawing.Size(152, 6);
+            this.toolStripMenuItem1.Size = new System.Drawing.Size(216, 6);
             // 
             // itensToolStripMenuItem
             // 
@@ -1249,20 +1276,20 @@
             this.itemsOnSDCardToolStripMenuItem,
             this.itemsNotOnSDCardToolStripMenuItem});
             this.itensToolStripMenuItem.Name = "itensToolStripMenuItem";
-            this.itensToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
+            this.itensToolStripMenuItem.Size = new System.Drawing.Size(219, 30);
             this.itensToolStripMenuItem.Text = "SD card";
             // 
             // itemsOnSDCardToolStripMenuItem
             // 
             this.itemsOnSDCardToolStripMenuItem.Name = "itemsOnSDCardToolStripMenuItem";
-            this.itemsOnSDCardToolStripMenuItem.Size = new System.Drawing.Size(184, 22);
+            this.itemsOnSDCardToolStripMenuItem.Size = new System.Drawing.Size(265, 30);
             this.itemsOnSDCardToolStripMenuItem.Text = "Items on SD card";
             this.itemsOnSDCardToolStripMenuItem.Click += new System.EventHandler(this.itemsOnSDCardToolStripMenuItem_Click);
             // 
             // itemsNotOnSDCardToolStripMenuItem
             // 
             this.itemsNotOnSDCardToolStripMenuItem.Name = "itemsNotOnSDCardToolStripMenuItem";
-            this.itemsNotOnSDCardToolStripMenuItem.Size = new System.Drawing.Size(184, 22);
+            this.itemsNotOnSDCardToolStripMenuItem.Size = new System.Drawing.Size(265, 30);
             this.itemsNotOnSDCardToolStripMenuItem.Text = "Items not on SD card";
             this.itemsNotOnSDCardToolStripMenuItem.Click += new System.EventHandler(this.itemsNotOnSDCardToolStripMenuItem_Click);
             // 
@@ -1272,20 +1299,20 @@
             this.itemsOnSceneReleasesToolStripMenuItem,
             this.itemsNotOnSceneReleasesToolStripMenuItem});
             this.sceneReleasesToolStripMenuItem.Name = "sceneReleasesToolStripMenuItem";
-            this.sceneReleasesToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
+            this.sceneReleasesToolStripMenuItem.Size = new System.Drawing.Size(219, 30);
             this.sceneReleasesToolStripMenuItem.Text = "Scene releases";
             // 
             // itemsOnSceneReleasesToolStripMenuItem
             // 
             this.itemsOnSceneReleasesToolStripMenuItem.Name = "itemsOnSceneReleasesToolStripMenuItem";
-            this.itemsOnSceneReleasesToolStripMenuItem.Size = new System.Drawing.Size(219, 22);
+            this.itemsOnSceneReleasesToolStripMenuItem.Size = new System.Drawing.Size(316, 30);
             this.itemsOnSceneReleasesToolStripMenuItem.Text = "Items on Scene releases";
             this.itemsOnSceneReleasesToolStripMenuItem.Click += new System.EventHandler(this.itemsOnSceneReleasesToolStripMenuItem_Click);
             // 
             // itemsNotOnSceneReleasesToolStripMenuItem
             // 
             this.itemsNotOnSceneReleasesToolStripMenuItem.Name = "itemsNotOnSceneReleasesToolStripMenuItem";
-            this.itemsNotOnSceneReleasesToolStripMenuItem.Size = new System.Drawing.Size(219, 22);
+            this.itemsNotOnSceneReleasesToolStripMenuItem.Size = new System.Drawing.Size(316, 30);
             this.itemsNotOnSceneReleasesToolStripMenuItem.Text = "Items not on Scene releases";
             this.itemsNotOnSceneReleasesToolStripMenuItem.Click += new System.EventHandler(this.itemsNotOnSceneReleasesToolStripMenuItem_Click);
             // 
@@ -1294,13 +1321,13 @@
             this.eshopReleasesToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.itemsOnEshjToolStripMenuItem});
             this.eshopReleasesToolStripMenuItem.Name = "eshopReleasesToolStripMenuItem";
-            this.eshopReleasesToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
+            this.eshopReleasesToolStripMenuItem.Size = new System.Drawing.Size(219, 30);
             this.eshopReleasesToolStripMenuItem.Text = "E-shop releases";
             // 
             // itemsOnEshjToolStripMenuItem
             // 
             this.itemsOnEshjToolStripMenuItem.Name = "itemsOnEshjToolStripMenuItem";
-            this.itemsOnEshjToolStripMenuItem.Size = new System.Drawing.Size(178, 22);
+            this.itemsOnEshjToolStripMenuItem.Size = new System.Drawing.Size(254, 30);
             this.itemsOnEshjToolStripMenuItem.Text = "Items on e-shop list";
             this.itemsOnEshjToolStripMenuItem.Click += new System.EventHandler(this.itemsOnEshjToolStripMenuItem_Click);
             // 
@@ -1315,55 +1342,55 @@
             this.developerToolStripMenuItem,
             this.masterkeyRevisionToolStripMenuItem});
             this.listToolStripMenuItem.Name = "listToolStripMenuItem";
-            this.listToolStripMenuItem.Size = new System.Drawing.Size(69, 20);
+            this.listToolStripMenuItem.Size = new System.Drawing.Size(99, 29);
             this.listToolStripMenuItem.Text = "&Grouping";
             // 
             // noneToolStripMenuItem1
             // 
             this.noneToolStripMenuItem1.Name = "noneToolStripMenuItem1";
-            this.noneToolStripMenuItem1.Size = new System.Drawing.Size(172, 22);
+            this.noneToolStripMenuItem1.Size = new System.Drawing.Size(243, 30);
             this.noneToolStripMenuItem1.Text = "None";
             this.noneToolStripMenuItem1.Click += new System.EventHandler(this.noneToolStripMenuItem1_Click);
             // 
             // gameTitleToolStripMenuItem
             // 
             this.gameTitleToolStripMenuItem.Name = "gameTitleToolStripMenuItem";
-            this.gameTitleToolStripMenuItem.Size = new System.Drawing.Size(172, 22);
+            this.gameTitleToolStripMenuItem.Size = new System.Drawing.Size(243, 30);
             this.gameTitleToolStripMenuItem.Text = "Game title";
             this.gameTitleToolStripMenuItem.Click += new System.EventHandler(this.gameTitleToolStripMenuItem_Click);
             // 
             // trimmedToolStripMenuItem
             // 
             this.trimmedToolStripMenuItem.Name = "trimmedToolStripMenuItem";
-            this.trimmedToolStripMenuItem.Size = new System.Drawing.Size(172, 22);
+            this.trimmedToolStripMenuItem.Size = new System.Drawing.Size(243, 30);
             this.trimmedToolStripMenuItem.Text = "Trimmed";
             this.trimmedToolStripMenuItem.Click += new System.EventHandler(this.trimmedToolStripMenuItem_Click);
             // 
             // cartSizeToolStripMenuItem
             // 
             this.cartSizeToolStripMenuItem.Name = "cartSizeToolStripMenuItem";
-            this.cartSizeToolStripMenuItem.Size = new System.Drawing.Size(172, 22);
+            this.cartSizeToolStripMenuItem.Size = new System.Drawing.Size(243, 30);
             this.cartSizeToolStripMenuItem.Text = "Cart size";
             this.cartSizeToolStripMenuItem.Click += new System.EventHandler(this.cartSizeToolStripMenuItem_Click);
             // 
             // typeToolStripMenuItem
             // 
             this.typeToolStripMenuItem.Name = "typeToolStripMenuItem";
-            this.typeToolStripMenuItem.Size = new System.Drawing.Size(172, 22);
+            this.typeToolStripMenuItem.Size = new System.Drawing.Size(243, 30);
             this.typeToolStripMenuItem.Text = "Type";
             this.typeToolStripMenuItem.Click += new System.EventHandler(this.typeToolStripMenuItem_Click);
             // 
             // developerToolStripMenuItem
             // 
             this.developerToolStripMenuItem.Name = "developerToolStripMenuItem";
-            this.developerToolStripMenuItem.Size = new System.Drawing.Size(172, 22);
+            this.developerToolStripMenuItem.Size = new System.Drawing.Size(243, 30);
             this.developerToolStripMenuItem.Text = "Developer";
             this.developerToolStripMenuItem.Click += new System.EventHandler(this.developerToolStripMenuItem_Click);
             // 
             // masterkeyRevisionToolStripMenuItem
             // 
             this.masterkeyRevisionToolStripMenuItem.Name = "masterkeyRevisionToolStripMenuItem";
-            this.masterkeyRevisionToolStripMenuItem.Size = new System.Drawing.Size(172, 22);
+            this.masterkeyRevisionToolStripMenuItem.Size = new System.Drawing.Size(243, 30);
             this.masterkeyRevisionToolStripMenuItem.Text = "Masterkey revision";
             this.masterkeyRevisionToolStripMenuItem.Click += new System.EventHandler(this.masterkeyRevisionToolStripMenuItem_Click);
             // 
@@ -1375,20 +1402,20 @@
             this.sDCardToolStripMenuItem,
             this.sceneReleasesToolStripMenuItem1});
             this.removeToolStripMenuItem.Name = "removeToolStripMenuItem";
-            this.removeToolStripMenuItem.Size = new System.Drawing.Size(117, 20);
+            this.removeToolStripMenuItem.Size = new System.Drawing.Size(169, 29);
             this.removeToolStripMenuItem.Text = "&Remove (from list)";
             // 
             // selectedToolStripMenuItem
             // 
             this.selectedToolStripMenuItem.Name = "selectedToolStripMenuItem";
-            this.selectedToolStripMenuItem.Size = new System.Drawing.Size(149, 22);
+            this.selectedToolStripMenuItem.Size = new System.Drawing.Size(209, 30);
             this.selectedToolStripMenuItem.Text = "Selected";
             this.selectedToolStripMenuItem.Click += new System.EventHandler(this.selectedToolStripMenuItem_Click);
             // 
             // toolStripMenuItem2
             // 
             this.toolStripMenuItem2.Name = "toolStripMenuItem2";
-            this.toolStripMenuItem2.Size = new System.Drawing.Size(146, 6);
+            this.toolStripMenuItem2.Size = new System.Drawing.Size(206, 6);
             this.toolStripMenuItem2.Visible = false;
             // 
             // sDCardToolStripMenuItem
@@ -1397,20 +1424,20 @@
             this.itemsOnSDCardToolStripMenuItem1,
             this.itemsNotOnSDCardToolStripMenuItem1});
             this.sDCardToolStripMenuItem.Name = "sDCardToolStripMenuItem";
-            this.sDCardToolStripMenuItem.Size = new System.Drawing.Size(149, 22);
+            this.sDCardToolStripMenuItem.Size = new System.Drawing.Size(209, 30);
             this.sDCardToolStripMenuItem.Text = "SD card";
             this.sDCardToolStripMenuItem.Visible = false;
             // 
             // itemsOnSDCardToolStripMenuItem1
             // 
             this.itemsOnSDCardToolStripMenuItem1.Name = "itemsOnSDCardToolStripMenuItem1";
-            this.itemsOnSDCardToolStripMenuItem1.Size = new System.Drawing.Size(184, 22);
+            this.itemsOnSDCardToolStripMenuItem1.Size = new System.Drawing.Size(265, 30);
             this.itemsOnSDCardToolStripMenuItem1.Text = "Items on SD card";
             // 
             // itemsNotOnSDCardToolStripMenuItem1
             // 
             this.itemsNotOnSDCardToolStripMenuItem1.Name = "itemsNotOnSDCardToolStripMenuItem1";
-            this.itemsNotOnSDCardToolStripMenuItem1.Size = new System.Drawing.Size(184, 22);
+            this.itemsNotOnSDCardToolStripMenuItem1.Size = new System.Drawing.Size(265, 30);
             this.itemsNotOnSDCardToolStripMenuItem1.Text = "Items not on SD card";
             // 
             // sceneReleasesToolStripMenuItem1
@@ -1419,20 +1446,20 @@
             this.itemsOnSceneReleasesToolStripMenuItem1,
             this.itemsNotOnSceneReleasesToolStripMenuItem1});
             this.sceneReleasesToolStripMenuItem1.Name = "sceneReleasesToolStripMenuItem1";
-            this.sceneReleasesToolStripMenuItem1.Size = new System.Drawing.Size(149, 22);
+            this.sceneReleasesToolStripMenuItem1.Size = new System.Drawing.Size(209, 30);
             this.sceneReleasesToolStripMenuItem1.Text = "Scene releases";
             this.sceneReleasesToolStripMenuItem1.Visible = false;
             // 
             // itemsOnSceneReleasesToolStripMenuItem1
             // 
             this.itemsOnSceneReleasesToolStripMenuItem1.Name = "itemsOnSceneReleasesToolStripMenuItem1";
-            this.itemsOnSceneReleasesToolStripMenuItem1.Size = new System.Drawing.Size(219, 22);
+            this.itemsOnSceneReleasesToolStripMenuItem1.Size = new System.Drawing.Size(316, 30);
             this.itemsOnSceneReleasesToolStripMenuItem1.Text = "Items on Scene releases";
             // 
             // itemsNotOnSceneReleasesToolStripMenuItem1
             // 
             this.itemsNotOnSceneReleasesToolStripMenuItem1.Name = "itemsNotOnSceneReleasesToolStripMenuItem1";
-            this.itemsNotOnSceneReleasesToolStripMenuItem1.Size = new System.Drawing.Size(219, 22);
+            this.itemsNotOnSceneReleasesToolStripMenuItem1.Size = new System.Drawing.Size(316, 30);
             this.itemsNotOnSceneReleasesToolStripMenuItem1.Text = "Items not on Scene releases";
             // 
             // transferToolStripMenuItem
@@ -1441,7 +1468,7 @@
             this.sDCardToolStripMenuItem1,
             this.folderToolStripMenuItem1});
             this.transferToolStripMenuItem.Name = "transferToolStripMenuItem";
-            this.transferToolStripMenuItem.Size = new System.Drawing.Size(75, 20);
+            this.transferToolStripMenuItem.Size = new System.Drawing.Size(107, 29);
             this.transferToolStripMenuItem.Text = "&Transfer to";
             // 
             // sDCardToolStripMenuItem1
@@ -1450,20 +1477,20 @@
             this.copyFilesToolStripMenuItem,
             this.moveFilesToolStripMenuItem});
             this.sDCardToolStripMenuItem1.Name = "sDCardToolStripMenuItem1";
-            this.sDCardToolStripMenuItem1.Size = new System.Drawing.Size(116, 22);
+            this.sDCardToolStripMenuItem1.Size = new System.Drawing.Size(158, 30);
             this.sDCardToolStripMenuItem1.Text = "SD card";
             // 
             // copyFilesToolStripMenuItem
             // 
             this.copyFilesToolStripMenuItem.Name = "copyFilesToolStripMenuItem";
-            this.copyFilesToolStripMenuItem.Size = new System.Drawing.Size(128, 22);
+            this.copyFilesToolStripMenuItem.Size = new System.Drawing.Size(177, 30);
             this.copyFilesToolStripMenuItem.Text = "Copy files";
             this.copyFilesToolStripMenuItem.Click += new System.EventHandler(this.copyFilesToolStripMenuItem_Click);
             // 
             // moveFilesToolStripMenuItem
             // 
             this.moveFilesToolStripMenuItem.Name = "moveFilesToolStripMenuItem";
-            this.moveFilesToolStripMenuItem.Size = new System.Drawing.Size(128, 22);
+            this.moveFilesToolStripMenuItem.Size = new System.Drawing.Size(177, 30);
             this.moveFilesToolStripMenuItem.Text = "Move files";
             this.moveFilesToolStripMenuItem.Click += new System.EventHandler(this.moveFilesToolStripMenuItem_Click);
             // 
@@ -1473,20 +1500,20 @@
             this.copyFilesToolStripMenuItem1,
             this.moveFilesToolStripMenuItem1});
             this.folderToolStripMenuItem1.Name = "folderToolStripMenuItem1";
-            this.folderToolStripMenuItem1.Size = new System.Drawing.Size(116, 22);
+            this.folderToolStripMenuItem1.Size = new System.Drawing.Size(158, 30);
             this.folderToolStripMenuItem1.Text = "Folder...";
             // 
             // copyFilesToolStripMenuItem1
             // 
             this.copyFilesToolStripMenuItem1.Name = "copyFilesToolStripMenuItem1";
-            this.copyFilesToolStripMenuItem1.Size = new System.Drawing.Size(128, 22);
+            this.copyFilesToolStripMenuItem1.Size = new System.Drawing.Size(177, 30);
             this.copyFilesToolStripMenuItem1.Text = "Copy files";
             this.copyFilesToolStripMenuItem1.Click += new System.EventHandler(this.copyFilesToolStripMenuItem1_Click);
             // 
             // moveFilesToolStripMenuItem1
             // 
             this.moveFilesToolStripMenuItem1.Name = "moveFilesToolStripMenuItem1";
-            this.moveFilesToolStripMenuItem1.Size = new System.Drawing.Size(128, 22);
+            this.moveFilesToolStripMenuItem1.Size = new System.Drawing.Size(177, 30);
             this.moveFilesToolStripMenuItem1.Text = "Move files";
             this.moveFilesToolStripMenuItem1.Click += new System.EventHandler(this.moveFilesToolStripMenuItem1_Click);
             // 
@@ -1496,20 +1523,20 @@
             this.updateToolStripMenuItem,
             this.updateNswdbcomListToolStripMenuItem});
             this.infosToolStripMenuItem.Name = "infosToolStripMenuItem";
-            this.infosToolStripMenuItem.Size = new System.Drawing.Size(45, 20);
+            this.infosToolStripMenuItem.Size = new System.Drawing.Size(64, 29);
             this.infosToolStripMenuItem.Text = "&Infos";
             this.infosToolStripMenuItem.Visible = false;
             // 
             // updateToolStripMenuItem
             // 
             this.updateToolStripMenuItem.Name = "updateToolStripMenuItem";
-            this.updateToolStripMenuItem.Size = new System.Drawing.Size(195, 22);
+            this.updateToolStripMenuItem.Size = new System.Drawing.Size(278, 30);
             this.updateToolStripMenuItem.Text = "Update local database";
             // 
             // updateNswdbcomListToolStripMenuItem
             // 
             this.updateNswdbcomListToolStripMenuItem.Name = "updateNswdbcomListToolStripMenuItem";
-            this.updateNswdbcomListToolStripMenuItem.Size = new System.Drawing.Size(195, 22);
+            this.updateNswdbcomListToolStripMenuItem.Size = new System.Drawing.Size(278, 30);
             this.updateNswdbcomListToolStripMenuItem.Text = "Update nswdb.com list";
             // 
             // toolsToolStripMenuItem
@@ -1521,7 +1548,7 @@
             this.toolStripMenuItem3,
             this.exportGameListToolStripMenuItem});
             this.toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
-            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(47, 20);
+            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(65, 29);
             this.toolsToolStripMenuItem.Text = "T&ools";
             // 
             // trimToolStripMenuItem
@@ -1530,20 +1557,20 @@
             this.selectedFilesToolStripMenuItem,
             this.allFilesToolStripMenuItem});
             this.trimToolStripMenuItem.Name = "trimToolStripMenuItem";
-            this.trimToolStripMenuItem.Size = new System.Drawing.Size(158, 22);
+            this.trimToolStripMenuItem.Size = new System.Drawing.Size(224, 30);
             this.trimToolStripMenuItem.Text = "Trim";
             // 
             // selectedFilesToolStripMenuItem
             // 
             this.selectedFilesToolStripMenuItem.Name = "selectedFilesToolStripMenuItem";
-            this.selectedFilesToolStripMenuItem.Size = new System.Drawing.Size(142, 22);
+            this.selectedFilesToolStripMenuItem.Size = new System.Drawing.Size(198, 30);
             this.selectedFilesToolStripMenuItem.Text = "Selected files";
             this.selectedFilesToolStripMenuItem.Click += new System.EventHandler(this.selectedFilesToolStripMenuItem_Click);
             // 
             // allFilesToolStripMenuItem
             // 
             this.allFilesToolStripMenuItem.Name = "allFilesToolStripMenuItem";
-            this.allFilesToolStripMenuItem.Size = new System.Drawing.Size(142, 22);
+            this.allFilesToolStripMenuItem.Size = new System.Drawing.Size(198, 30);
             this.allFilesToolStripMenuItem.Text = "All files";
             this.allFilesToolStripMenuItem.Click += new System.EventHandler(this.allFilesToolStripMenuItem_Click);
             // 
@@ -1553,34 +1580,34 @@
             this.selectedFilesToolStripMenuItem1,
             this.allFilesToolStripMenuItem1});
             this.renameToolStripMenuItem.Name = "renameToolStripMenuItem";
-            this.renameToolStripMenuItem.Size = new System.Drawing.Size(158, 22);
+            this.renameToolStripMenuItem.Size = new System.Drawing.Size(224, 30);
             this.renameToolStripMenuItem.Text = "Auto rename";
             // 
             // selectedFilesToolStripMenuItem1
             // 
             this.selectedFilesToolStripMenuItem1.Name = "selectedFilesToolStripMenuItem1";
-            this.selectedFilesToolStripMenuItem1.Size = new System.Drawing.Size(142, 22);
+            this.selectedFilesToolStripMenuItem1.Size = new System.Drawing.Size(198, 30);
             this.selectedFilesToolStripMenuItem1.Text = "Selected files";
             this.selectedFilesToolStripMenuItem1.Click += new System.EventHandler(this.selectedFilesToolStripMenuItem1_Click);
             // 
             // allFilesToolStripMenuItem1
             // 
             this.allFilesToolStripMenuItem1.Name = "allFilesToolStripMenuItem1";
-            this.allFilesToolStripMenuItem1.Size = new System.Drawing.Size(142, 22);
+            this.allFilesToolStripMenuItem1.Size = new System.Drawing.Size(198, 30);
             this.allFilesToolStripMenuItem1.Text = "All files";
             this.allFilesToolStripMenuItem1.Click += new System.EventHandler(this.allFilesToolStripMenuItem1_Click);
             // 
             // exportListToolStripMenuItem
             // 
             this.exportListToolStripMenuItem.Name = "exportListToolStripMenuItem";
-            this.exportListToolStripMenuItem.Size = new System.Drawing.Size(158, 22);
+            this.exportListToolStripMenuItem.Size = new System.Drawing.Size(224, 30);
             this.exportListToolStripMenuItem.Text = "Extract file...";
             this.exportListToolStripMenuItem.Visible = false;
             // 
             // toolStripMenuItem3
             // 
             this.toolStripMenuItem3.Name = "toolStripMenuItem3";
-            this.toolStripMenuItem3.Size = new System.Drawing.Size(155, 6);
+            this.toolStripMenuItem3.Size = new System.Drawing.Size(221, 6);
             // 
             // exportGameListToolStripMenuItem
             // 
@@ -1588,20 +1615,20 @@
             this.htmlToolStripMenuItem,
             this.cSVToolStripMenuItem});
             this.exportGameListToolStripMenuItem.Name = "exportGameListToolStripMenuItem";
-            this.exportGameListToolStripMenuItem.Size = new System.Drawing.Size(158, 22);
+            this.exportGameListToolStripMenuItem.Size = new System.Drawing.Size(224, 30);
             this.exportGameListToolStripMenuItem.Text = "Export game list";
             this.exportGameListToolStripMenuItem.Visible = false;
             // 
             // htmlToolStripMenuItem
             // 
             this.htmlToolStripMenuItem.Name = "htmlToolStripMenuItem";
-            this.htmlToolStripMenuItem.Size = new System.Drawing.Size(107, 22);
+            this.htmlToolStripMenuItem.Size = new System.Drawing.Size(142, 30);
             this.htmlToolStripMenuItem.Text = "HTML";
             // 
             // cSVToolStripMenuItem
             // 
             this.cSVToolStripMenuItem.Name = "cSVToolStripMenuItem";
-            this.cSVToolStripMenuItem.Size = new System.Drawing.Size(107, 22);
+            this.cSVToolStripMenuItem.Size = new System.Drawing.Size(142, 30);
             this.cSVToolStripMenuItem.Text = "CSV";
             // 
             // tabPage2
@@ -1613,19 +1640,21 @@
             this.tabPage2.Controls.Add(this.OLV_SDCard);
             this.tabPage2.Controls.Add(this.panel5);
             this.tabPage2.Controls.Add(this.menuSDFiles);
-            this.tabPage2.Location = new System.Drawing.Point(4, 22);
+            this.tabPage2.Location = new System.Drawing.Point(4, 29);
+            this.tabPage2.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.tabPage2.Name = "tabPage2";
-            this.tabPage2.Padding = new System.Windows.Forms.Padding(3, 3, 3, 3);
-            this.tabPage2.Size = new System.Drawing.Size(1518, 491);
+            this.tabPage2.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.tabPage2.Size = new System.Drawing.Size(2281, 752);
             this.tabPage2.TabIndex = 1;
             this.tabPage2.Text = "SD card";
             this.tabPage2.UseVisualStyleBackColor = true;
             // 
             // btnClearFilterSD
             // 
-            this.btnClearFilterSD.Location = new System.Drawing.Point(1441, 3);
+            this.btnClearFilterSD.Location = new System.Drawing.Point(2162, 5);
+            this.btnClearFilterSD.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.btnClearFilterSD.Name = "btnClearFilterSD";
-            this.btnClearFilterSD.Size = new System.Drawing.Size(75, 23);
+            this.btnClearFilterSD.Size = new System.Drawing.Size(112, 35);
             this.btnClearFilterSD.TabIndex = 10;
             this.btnClearFilterSD.Text = "Clear";
             this.btnClearFilterSD.UseVisualStyleBackColor = true;
@@ -1633,18 +1662,20 @@
             // 
             // textBoxFilterSD
             // 
-            this.textBoxFilterSD.Location = new System.Drawing.Point(1166, 5);
+            this.textBoxFilterSD.Location = new System.Drawing.Point(1749, 8);
+            this.textBoxFilterSD.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.textBoxFilterSD.Name = "textBoxFilterSD";
-            this.textBoxFilterSD.Size = new System.Drawing.Size(268, 20);
+            this.textBoxFilterSD.Size = new System.Drawing.Size(400, 26);
             this.textBoxFilterSD.TabIndex = 9;
             this.textBoxFilterSD.TextChanged += new System.EventHandler(this.textBoxFilterSD_TextChanged);
             // 
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(1022, 8);
+            this.label3.Location = new System.Drawing.Point(1533, 12);
+            this.label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(32, 13);
+            this.label3.Size = new System.Drawing.Size(48, 20);
             this.label3.TabIndex = 8;
             this.label3.Text = "Filter:";
             // 
@@ -1652,9 +1683,10 @@
             // 
             this.cbxFilterSD.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cbxFilterSD.FormattingEnabled = true;
-            this.cbxFilterSD.Location = new System.Drawing.Point(1057, 4);
+            this.cbxFilterSD.Location = new System.Drawing.Point(1586, 6);
+            this.cbxFilterSD.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.cbxFilterSD.Name = "cbxFilterSD";
-            this.cbxFilterSD.Size = new System.Drawing.Size(102, 21);
+            this.cbxFilterSD.Size = new System.Drawing.Size(151, 28);
             this.cbxFilterSD.TabIndex = 7;
             this.cbxFilterSD.SelectedIndexChanged += new System.EventHandler(this.cbxFilterSD_SelectedIndexChanged);
             // 
@@ -1701,10 +1733,11 @@
             this.OLV_SDCard.Dock = System.Windows.Forms.DockStyle.Fill;
             this.OLV_SDCard.FullRowSelect = true;
             this.OLV_SDCard.GridLines = true;
-            this.OLV_SDCard.Location = new System.Drawing.Point(3, 55);
+            this.OLV_SDCard.Location = new System.Drawing.Point(4, 83);
+            this.OLV_SDCard.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.OLV_SDCard.Name = "OLV_SDCard";
             this.OLV_SDCard.ShowGroups = false;
-            this.OLV_SDCard.Size = new System.Drawing.Size(1512, 433);
+            this.OLV_SDCard.Size = new System.Drawing.Size(2273, 664);
             this.OLV_SDCard.TabIndex = 6;
             this.OLV_SDCard.UseCellFormatEvents = true;
             this.OLV_SDCard.UseCompatibleStateImageBehavior = false;
@@ -1840,75 +1873,75 @@
             this.toolStripMenuItem97SDCard,
             this.deleteSelectedFileserasesFromDiskToolStripMenuItemSDCard});
             this.contextMenuStripSDCard.Name = "contextMenuStripSDCard";
-            this.contextMenuStripSDCard.Size = new System.Drawing.Size(277, 182);
+            this.contextMenuStripSDCard.Size = new System.Drawing.Size(390, 238);
             this.contextMenuStripSDCard.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenuStripSDCard_Opening);
             // 
             // showInExplorerToolStripMenuItem1
             // 
             this.showInExplorerToolStripMenuItem1.Name = "showInExplorerToolStripMenuItem1";
-            this.showInExplorerToolStripMenuItem1.Size = new System.Drawing.Size(276, 22);
+            this.showInExplorerToolStripMenuItem1.Size = new System.Drawing.Size(389, 30);
             this.showInExplorerToolStripMenuItem1.Text = "Show in explorer";
             this.showInExplorerToolStripMenuItem1.Click += new System.EventHandler(this.showInExplorerToolStripMenuItem1_Click);
             // 
             // toolStripMenuItem21
             // 
             this.toolStripMenuItem21.Name = "toolStripMenuItem21";
-            this.toolStripMenuItem21.Size = new System.Drawing.Size(273, 6);
+            this.toolStripMenuItem21.Size = new System.Drawing.Size(386, 6);
             // 
             // trimFilesToolStripMenuItemTrimSD
             // 
             this.trimFilesToolStripMenuItemTrimSD.Name = "trimFilesToolStripMenuItemTrimSD";
-            this.trimFilesToolStripMenuItemTrimSD.Size = new System.Drawing.Size(276, 22);
+            this.trimFilesToolStripMenuItemTrimSD.Size = new System.Drawing.Size(389, 30);
             this.trimFilesToolStripMenuItemTrimSD.Text = "Trim files";
             this.trimFilesToolStripMenuItemTrimSD.Click += new System.EventHandler(this.trimFilesToolStripMenuItem1_Click);
             // 
             // autoRenameFilesToolStripMenuItemRenameSD
             // 
             this.autoRenameFilesToolStripMenuItemRenameSD.Name = "autoRenameFilesToolStripMenuItemRenameSD";
-            this.autoRenameFilesToolStripMenuItemRenameSD.Size = new System.Drawing.Size(276, 22);
+            this.autoRenameFilesToolStripMenuItemRenameSD.Size = new System.Drawing.Size(389, 30);
             this.autoRenameFilesToolStripMenuItemRenameSD.Text = "Auto rename files";
             this.autoRenameFilesToolStripMenuItemRenameSD.Click += new System.EventHandler(this.autoRenameFilesToolStripMenuItemRenameSD_Click);
             // 
             // toolStripMenuItem18
             // 
             this.toolStripMenuItem18.Name = "toolStripMenuItem18";
-            this.toolStripMenuItem18.Size = new System.Drawing.Size(273, 6);
+            this.toolStripMenuItem18.Size = new System.Drawing.Size(386, 6);
             // 
             // copyToFolderToolStripMenuItem
             // 
             this.copyToFolderToolStripMenuItem.Name = "copyToFolderToolStripMenuItem";
-            this.copyToFolderToolStripMenuItem.Size = new System.Drawing.Size(276, 22);
+            this.copyToFolderToolStripMenuItem.Size = new System.Drawing.Size(389, 30);
             this.copyToFolderToolStripMenuItem.Text = "Copy to folder...";
             this.copyToFolderToolStripMenuItem.Click += new System.EventHandler(this.copyToFolderToolStripMenuItem_Click);
             // 
             // moveToFolderToolStripMenuItem
             // 
             this.moveToFolderToolStripMenuItem.Name = "moveToFolderToolStripMenuItem";
-            this.moveToFolderToolStripMenuItem.Size = new System.Drawing.Size(276, 22);
+            this.moveToFolderToolStripMenuItem.Size = new System.Drawing.Size(389, 30);
             this.moveToFolderToolStripMenuItem.Text = "Move to folder...";
             this.moveToFolderToolStripMenuItem.Click += new System.EventHandler(this.moveToFolderToolStripMenuItem_Click);
             // 
             // toolStripMenuItem70
             // 
             this.toolStripMenuItem70.Name = "toolStripMenuItem70";
-            this.toolStripMenuItem70.Size = new System.Drawing.Size(273, 6);
+            this.toolStripMenuItem70.Size = new System.Drawing.Size(386, 6);
             // 
             // copyInfoToClipboardToolStripMenuItem2
             // 
             this.copyInfoToClipboardToolStripMenuItem2.Name = "copyInfoToClipboardToolStripMenuItem2";
-            this.copyInfoToClipboardToolStripMenuItem2.Size = new System.Drawing.Size(276, 22);
+            this.copyInfoToClipboardToolStripMenuItem2.Size = new System.Drawing.Size(389, 30);
             this.copyInfoToClipboardToolStripMenuItem2.Text = "Copy info to clipboard";
             this.copyInfoToClipboardToolStripMenuItem2.Click += new System.EventHandler(this.copyInfoToClipboardToolStripMenuItem2_Click);
             // 
             // toolStripMenuItem97SDCard
             // 
             this.toolStripMenuItem97SDCard.Name = "toolStripMenuItem97SDCard";
-            this.toolStripMenuItem97SDCard.Size = new System.Drawing.Size(273, 6);
+            this.toolStripMenuItem97SDCard.Size = new System.Drawing.Size(386, 6);
             // 
             // deleteSelectedFileserasesFromDiskToolStripMenuItemSDCard
             // 
             this.deleteSelectedFileserasesFromDiskToolStripMenuItemSDCard.Name = "deleteSelectedFileserasesFromDiskToolStripMenuItemSDCard";
-            this.deleteSelectedFileserasesFromDiskToolStripMenuItemSDCard.Size = new System.Drawing.Size(276, 22);
+            this.deleteSelectedFileserasesFromDiskToolStripMenuItemSDCard.Size = new System.Drawing.Size(389, 30);
             this.deleteSelectedFileserasesFromDiskToolStripMenuItemSDCard.Text = "Delete selected files (erases from disk!)";
             this.deleteSelectedFileserasesFromDiskToolStripMenuItemSDCard.Click += new System.EventHandler(this.deleteSelectedFileserasesFromDiskToolStripMenuItemSDCard_Click);
             // 
@@ -1918,27 +1951,30 @@
             this.panel5.Controls.Add(this.label1);
             this.panel5.Controls.Add(this.cbxRemoveableDrives);
             this.panel5.Dock = System.Windows.Forms.DockStyle.Top;
-            this.panel5.Location = new System.Drawing.Point(3, 27);
+            this.panel5.Location = new System.Drawing.Point(4, 40);
+            this.panel5.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.panel5.Name = "panel5";
-            this.panel5.Size = new System.Drawing.Size(1512, 28);
+            this.panel5.Size = new System.Drawing.Size(2273, 43);
             this.panel5.TabIndex = 5;
             // 
             // lblSpaceAvailabeOnSD
             // 
             this.lblSpaceAvailabeOnSD.AutoSize = true;
             this.lblSpaceAvailabeOnSD.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblSpaceAvailabeOnSD.Location = new System.Drawing.Point(185, 8);
+            this.lblSpaceAvailabeOnSD.Location = new System.Drawing.Point(278, 12);
+            this.lblSpaceAvailabeOnSD.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblSpaceAvailabeOnSD.Name = "lblSpaceAvailabeOnSD";
-            this.lblSpaceAvailabeOnSD.Size = new System.Drawing.Size(144, 13);
+            this.lblSpaceAvailabeOnSD.Size = new System.Drawing.Size(211, 20);
             this.lblSpaceAvailabeOnSD.TabIndex = 2;
             this.lblSpaceAvailabeOnSD.Text = "Available space: 100MB";
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(2, 7);
+            this.label1.Location = new System.Drawing.Point(3, 11);
+            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(108, 13);
+            this.label1.Size = new System.Drawing.Size(157, 20);
             this.label1.TabIndex = 1;
             this.label1.Text = "Select SD card drive:";
             // 
@@ -1946,9 +1982,10 @@
             // 
             this.cbxRemoveableDrives.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cbxRemoveableDrives.FormattingEnabled = true;
-            this.cbxRemoveableDrives.Location = new System.Drawing.Point(115, 4);
+            this.cbxRemoveableDrives.Location = new System.Drawing.Point(172, 6);
+            this.cbxRemoveableDrives.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.cbxRemoveableDrives.Name = "cbxRemoveableDrives";
-            this.cbxRemoveableDrives.Size = new System.Drawing.Size(64, 21);
+            this.cbxRemoveableDrives.Size = new System.Drawing.Size(94, 28);
             this.cbxRemoveableDrives.TabIndex = 0;
             this.cbxRemoveableDrives.DropDown += new System.EventHandler(this.cbxRemoveableDrives_DropDown);
             this.cbxRemoveableDrives.SelectedIndexChanged += new System.EventHandler(this.cbxRemoveableDrives_SelectedIndexChanged);
@@ -1965,9 +2002,10 @@
             this.toolStripMenuItem33,
             this.toolStripMenuItem36,
             this.toolStripMenuItem39});
-            this.menuSDFiles.Location = new System.Drawing.Point(3, 3);
+            this.menuSDFiles.Location = new System.Drawing.Point(4, 5);
             this.menuSDFiles.Name = "menuSDFiles";
-            this.menuSDFiles.Size = new System.Drawing.Size(1512, 24);
+            this.menuSDFiles.Padding = new System.Windows.Forms.Padding(9, 3, 0, 3);
+            this.menuSDFiles.Size = new System.Drawing.Size(2273, 35);
             this.menuSDFiles.TabIndex = 4;
             // 
             // toolStripMenuItem4
@@ -1976,20 +2014,20 @@
             this.toolStripMenuItem5,
             this.toolStripMenuItem6});
             this.toolStripMenuItem4.Name = "toolStripMenuItem4";
-            this.toolStripMenuItem4.Size = new System.Drawing.Size(41, 20);
+            this.toolStripMenuItem4.Size = new System.Drawing.Size(58, 29);
             this.toolStripMenuItem4.Text = "&Add";
             this.toolStripMenuItem4.Visible = false;
             // 
             // toolStripMenuItem5
             // 
             this.toolStripMenuItem5.Name = "toolStripMenuItem5";
-            this.toolStripMenuItem5.Size = new System.Drawing.Size(116, 22);
+            this.toolStripMenuItem5.Size = new System.Drawing.Size(158, 30);
             this.toolStripMenuItem5.Text = "Files";
             // 
             // toolStripMenuItem6
             // 
             this.toolStripMenuItem6.Name = "toolStripMenuItem6";
-            this.toolStripMenuItem6.Size = new System.Drawing.Size(116, 22);
+            this.toolStripMenuItem6.Size = new System.Drawing.Size(158, 30);
             this.toolStripMenuItem6.Text = "Folder...";
             // 
             // toolStripMenuItem7
@@ -2002,34 +2040,34 @@
             this.toolStripMenuItem11,
             this.toolStripMenuItem14});
             this.toolStripMenuItem7.Name = "toolStripMenuItem7";
-            this.toolStripMenuItem7.Size = new System.Drawing.Size(50, 20);
+            this.toolStripMenuItem7.Size = new System.Drawing.Size(70, 29);
             this.toolStripMenuItem7.Text = "&Select";
             // 
             // toolStripMenuItem8
             // 
             this.toolStripMenuItem8.Name = "toolStripMenuItem8";
-            this.toolStripMenuItem8.Size = new System.Drawing.Size(154, 22);
+            this.toolStripMenuItem8.Size = new System.Drawing.Size(215, 30);
             this.toolStripMenuItem8.Text = "All";
             this.toolStripMenuItem8.Click += new System.EventHandler(this.toolStripMenuItem8_Click);
             // 
             // toolStripMenuItem9
             // 
             this.toolStripMenuItem9.Name = "toolStripMenuItem9";
-            this.toolStripMenuItem9.Size = new System.Drawing.Size(154, 22);
+            this.toolStripMenuItem9.Size = new System.Drawing.Size(215, 30);
             this.toolStripMenuItem9.Text = "None";
             this.toolStripMenuItem9.Click += new System.EventHandler(this.toolStripMenuItem9_Click);
             // 
             // toolStripMenuItem10
             // 
             this.toolStripMenuItem10.Name = "toolStripMenuItem10";
-            this.toolStripMenuItem10.Size = new System.Drawing.Size(154, 22);
+            this.toolStripMenuItem10.Size = new System.Drawing.Size(215, 30);
             this.toolStripMenuItem10.Text = "Invert selection";
             this.toolStripMenuItem10.Click += new System.EventHandler(this.toolStripMenuItem10_Click);
             // 
             // toolStripSeparator1
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(151, 6);
+            this.toolStripSeparator1.Size = new System.Drawing.Size(212, 6);
             // 
             // toolStripMenuItem11
             // 
@@ -2037,20 +2075,20 @@
             this.toolStripMenuItem12,
             this.toolStripMenuItem13});
             this.toolStripMenuItem11.Name = "toolStripMenuItem11";
-            this.toolStripMenuItem11.Size = new System.Drawing.Size(154, 22);
+            this.toolStripMenuItem11.Size = new System.Drawing.Size(215, 30);
             this.toolStripMenuItem11.Text = "Local files";
             // 
             // toolStripMenuItem12
             // 
             this.toolStripMenuItem12.Name = "toolStripMenuItem12";
-            this.toolStripMenuItem12.Size = new System.Drawing.Size(190, 22);
+            this.toolStripMenuItem12.Size = new System.Drawing.Size(270, 30);
             this.toolStripMenuItem12.Text = "Items on local files";
             this.toolStripMenuItem12.Click += new System.EventHandler(this.toolStripMenuItem12_Click);
             // 
             // toolStripMenuItem13
             // 
             this.toolStripMenuItem13.Name = "toolStripMenuItem13";
-            this.toolStripMenuItem13.Size = new System.Drawing.Size(190, 22);
+            this.toolStripMenuItem13.Size = new System.Drawing.Size(270, 30);
             this.toolStripMenuItem13.Text = "Items not on localfiles";
             this.toolStripMenuItem13.Click += new System.EventHandler(this.toolStripMenuItem13_Click);
             // 
@@ -2060,20 +2098,20 @@
             this.toolStripMenuItem15,
             this.toolStripMenuItem16});
             this.toolStripMenuItem14.Name = "toolStripMenuItem14";
-            this.toolStripMenuItem14.Size = new System.Drawing.Size(154, 22);
+            this.toolStripMenuItem14.Size = new System.Drawing.Size(215, 30);
             this.toolStripMenuItem14.Text = "Scene releases";
             // 
             // toolStripMenuItem15
             // 
             this.toolStripMenuItem15.Name = "toolStripMenuItem15";
-            this.toolStripMenuItem15.Size = new System.Drawing.Size(219, 22);
+            this.toolStripMenuItem15.Size = new System.Drawing.Size(316, 30);
             this.toolStripMenuItem15.Text = "Items on Scene releases";
             this.toolStripMenuItem15.Click += new System.EventHandler(this.toolStripMenuItem15_Click);
             // 
             // toolStripMenuItem16
             // 
             this.toolStripMenuItem16.Name = "toolStripMenuItem16";
-            this.toolStripMenuItem16.Size = new System.Drawing.Size(219, 22);
+            this.toolStripMenuItem16.Size = new System.Drawing.Size(316, 30);
             this.toolStripMenuItem16.Text = "Items not on Scene releases";
             this.toolStripMenuItem16.Click += new System.EventHandler(this.toolStripMenuItem16_Click);
             // 
@@ -2088,55 +2126,55 @@
             this.toolStripMenuItemGroupDeveloperSD,
             this.toolStripMenuItemGroupMasterkeySD});
             this.toolStripMenuItem17.Name = "toolStripMenuItem17";
-            this.toolStripMenuItem17.Size = new System.Drawing.Size(69, 20);
+            this.toolStripMenuItem17.Size = new System.Drawing.Size(99, 29);
             this.toolStripMenuItem17.Text = "&Grouping";
             // 
             // toolStripMenuItemGroupNoneSD
             // 
             this.toolStripMenuItemGroupNoneSD.Name = "toolStripMenuItemGroupNoneSD";
-            this.toolStripMenuItemGroupNoneSD.Size = new System.Drawing.Size(172, 22);
+            this.toolStripMenuItemGroupNoneSD.Size = new System.Drawing.Size(243, 30);
             this.toolStripMenuItemGroupNoneSD.Text = "None";
             this.toolStripMenuItemGroupNoneSD.Click += new System.EventHandler(this.toolStripMenuItemGroupNoneSD_Click);
             // 
             // toolStripMenuItemGroupGameTitleSD
             // 
             this.toolStripMenuItemGroupGameTitleSD.Name = "toolStripMenuItemGroupGameTitleSD";
-            this.toolStripMenuItemGroupGameTitleSD.Size = new System.Drawing.Size(172, 22);
+            this.toolStripMenuItemGroupGameTitleSD.Size = new System.Drawing.Size(243, 30);
             this.toolStripMenuItemGroupGameTitleSD.Text = "Game title";
             this.toolStripMenuItemGroupGameTitleSD.Click += new System.EventHandler(this.toolStripMenuItemGroupGameTitleSD_Click);
             // 
             // toolStripMenuItemGroupTrimmedSD
             // 
             this.toolStripMenuItemGroupTrimmedSD.Name = "toolStripMenuItemGroupTrimmedSD";
-            this.toolStripMenuItemGroupTrimmedSD.Size = new System.Drawing.Size(172, 22);
+            this.toolStripMenuItemGroupTrimmedSD.Size = new System.Drawing.Size(243, 30);
             this.toolStripMenuItemGroupTrimmedSD.Text = "Trimmed";
             this.toolStripMenuItemGroupTrimmedSD.Click += new System.EventHandler(this.toolStripMenuItemGroupTrimmedSD_Click);
             // 
             // toolStripMenuItemGroupCartSizeSD
             // 
             this.toolStripMenuItemGroupCartSizeSD.Name = "toolStripMenuItemGroupCartSizeSD";
-            this.toolStripMenuItemGroupCartSizeSD.Size = new System.Drawing.Size(172, 22);
+            this.toolStripMenuItemGroupCartSizeSD.Size = new System.Drawing.Size(243, 30);
             this.toolStripMenuItemGroupCartSizeSD.Text = "Cart size";
             this.toolStripMenuItemGroupCartSizeSD.Click += new System.EventHandler(this.toolStripMenuItemGroupCartSizeSD_Click);
             // 
             // toolStripMenuItemGroupTypeSD
             // 
             this.toolStripMenuItemGroupTypeSD.Name = "toolStripMenuItemGroupTypeSD";
-            this.toolStripMenuItemGroupTypeSD.Size = new System.Drawing.Size(172, 22);
+            this.toolStripMenuItemGroupTypeSD.Size = new System.Drawing.Size(243, 30);
             this.toolStripMenuItemGroupTypeSD.Text = "Type";
             this.toolStripMenuItemGroupTypeSD.Click += new System.EventHandler(this.toolStripMenuItemGroupTypeSD_Click);
             // 
             // toolStripMenuItemGroupDeveloperSD
             // 
             this.toolStripMenuItemGroupDeveloperSD.Name = "toolStripMenuItemGroupDeveloperSD";
-            this.toolStripMenuItemGroupDeveloperSD.Size = new System.Drawing.Size(172, 22);
+            this.toolStripMenuItemGroupDeveloperSD.Size = new System.Drawing.Size(243, 30);
             this.toolStripMenuItemGroupDeveloperSD.Text = "Developer";
             this.toolStripMenuItemGroupDeveloperSD.Click += new System.EventHandler(this.toolStripMenuItemGroupDeveloperSD_Click);
             // 
             // toolStripMenuItemGroupMasterkeySD
             // 
             this.toolStripMenuItemGroupMasterkeySD.Name = "toolStripMenuItemGroupMasterkeySD";
-            this.toolStripMenuItemGroupMasterkeySD.Size = new System.Drawing.Size(172, 22);
+            this.toolStripMenuItemGroupMasterkeySD.Size = new System.Drawing.Size(243, 30);
             this.toolStripMenuItemGroupMasterkeySD.Text = "Masterkey revision";
             this.toolStripMenuItemGroupMasterkeySD.Click += new System.EventHandler(this.toolStripMenuItemGroupMasterkeySD_Click);
             // 
@@ -2148,20 +2186,20 @@
             this.toolStripMenuItem27,
             this.toolStripMenuItem30});
             this.toolStripMenuItem25.Name = "toolStripMenuItem25";
-            this.toolStripMenuItem25.Size = new System.Drawing.Size(62, 20);
+            this.toolStripMenuItem25.Size = new System.Drawing.Size(88, 29);
             this.toolStripMenuItem25.Text = "&Remove";
             this.toolStripMenuItem25.Visible = false;
             // 
             // toolStripMenuItem26
             // 
             this.toolStripMenuItem26.Name = "toolStripMenuItem26";
-            this.toolStripMenuItem26.Size = new System.Drawing.Size(149, 22);
+            this.toolStripMenuItem26.Size = new System.Drawing.Size(209, 30);
             this.toolStripMenuItem26.Text = "Selected";
             // 
             // toolStripSeparator2
             // 
             this.toolStripSeparator2.Name = "toolStripSeparator2";
-            this.toolStripSeparator2.Size = new System.Drawing.Size(146, 6);
+            this.toolStripSeparator2.Size = new System.Drawing.Size(206, 6);
             // 
             // toolStripMenuItem27
             // 
@@ -2169,19 +2207,19 @@
             this.toolStripMenuItem28,
             this.toolStripMenuItem29});
             this.toolStripMenuItem27.Name = "toolStripMenuItem27";
-            this.toolStripMenuItem27.Size = new System.Drawing.Size(149, 22);
+            this.toolStripMenuItem27.Size = new System.Drawing.Size(209, 30);
             this.toolStripMenuItem27.Text = "SD card";
             // 
             // toolStripMenuItem28
             // 
             this.toolStripMenuItem28.Name = "toolStripMenuItem28";
-            this.toolStripMenuItem28.Size = new System.Drawing.Size(184, 22);
+            this.toolStripMenuItem28.Size = new System.Drawing.Size(265, 30);
             this.toolStripMenuItem28.Text = "Items on SD card";
             // 
             // toolStripMenuItem29
             // 
             this.toolStripMenuItem29.Name = "toolStripMenuItem29";
-            this.toolStripMenuItem29.Size = new System.Drawing.Size(184, 22);
+            this.toolStripMenuItem29.Size = new System.Drawing.Size(265, 30);
             this.toolStripMenuItem29.Text = "Items not on SD card";
             // 
             // toolStripMenuItem30
@@ -2190,19 +2228,19 @@
             this.toolStripMenuItem31,
             this.toolStripMenuItem32});
             this.toolStripMenuItem30.Name = "toolStripMenuItem30";
-            this.toolStripMenuItem30.Size = new System.Drawing.Size(149, 22);
+            this.toolStripMenuItem30.Size = new System.Drawing.Size(209, 30);
             this.toolStripMenuItem30.Text = "Scene releases";
             // 
             // toolStripMenuItem31
             // 
             this.toolStripMenuItem31.Name = "toolStripMenuItem31";
-            this.toolStripMenuItem31.Size = new System.Drawing.Size(219, 22);
+            this.toolStripMenuItem31.Size = new System.Drawing.Size(316, 30);
             this.toolStripMenuItem31.Text = "Items on Scene releases";
             // 
             // toolStripMenuItem32
             // 
             this.toolStripMenuItem32.Name = "toolStripMenuItem32";
-            this.toolStripMenuItem32.Size = new System.Drawing.Size(219, 22);
+            this.toolStripMenuItem32.Size = new System.Drawing.Size(316, 30);
             this.toolStripMenuItem32.Text = "Items not on Scene releases";
             // 
             // toolStripMenuItem33
@@ -2211,13 +2249,13 @@
             this.toolStripMenuItem34,
             this.toolStripMenuItem35});
             this.toolStripMenuItem33.Name = "toolStripMenuItem33";
-            this.toolStripMenuItem33.Size = new System.Drawing.Size(75, 20);
+            this.toolStripMenuItem33.Size = new System.Drawing.Size(107, 29);
             this.toolStripMenuItem33.Text = "&Transfer to";
             // 
             // toolStripMenuItem34
             // 
             this.toolStripMenuItem34.Name = "toolStripMenuItem34";
-            this.toolStripMenuItem34.Size = new System.Drawing.Size(114, 22);
+            this.toolStripMenuItem34.Size = new System.Drawing.Size(158, 30);
             this.toolStripMenuItem34.Text = "SD card";
             this.toolStripMenuItem34.Visible = false;
             // 
@@ -2227,20 +2265,20 @@
             this.copyToolStripMenuItem,
             this.moveToolStripMenuItem});
             this.toolStripMenuItem35.Name = "toolStripMenuItem35";
-            this.toolStripMenuItem35.Size = new System.Drawing.Size(114, 22);
+            this.toolStripMenuItem35.Size = new System.Drawing.Size(158, 30);
             this.toolStripMenuItem35.Text = "Folder";
             // 
             // copyToolStripMenuItem
             // 
             this.copyToolStripMenuItem.Name = "copyToolStripMenuItem";
-            this.copyToolStripMenuItem.Size = new System.Drawing.Size(137, 22);
+            this.copyToolStripMenuItem.Size = new System.Drawing.Size(189, 30);
             this.copyToolStripMenuItem.Text = "Copy files...";
             this.copyToolStripMenuItem.Click += new System.EventHandler(this.copyToolStripMenuItem_Click);
             // 
             // moveToolStripMenuItem
             // 
             this.moveToolStripMenuItem.Name = "moveToolStripMenuItem";
-            this.moveToolStripMenuItem.Size = new System.Drawing.Size(137, 22);
+            this.moveToolStripMenuItem.Size = new System.Drawing.Size(189, 30);
             this.moveToolStripMenuItem.Text = "Move files...";
             this.moveToolStripMenuItem.Click += new System.EventHandler(this.moveToolStripMenuItem_Click);
             // 
@@ -2250,20 +2288,20 @@
             this.toolStripMenuItem37,
             this.toolStripMenuItem38});
             this.toolStripMenuItem36.Name = "toolStripMenuItem36";
-            this.toolStripMenuItem36.Size = new System.Drawing.Size(45, 20);
+            this.toolStripMenuItem36.Size = new System.Drawing.Size(64, 29);
             this.toolStripMenuItem36.Text = "&Infos";
             this.toolStripMenuItem36.Visible = false;
             // 
             // toolStripMenuItem37
             // 
             this.toolStripMenuItem37.Name = "toolStripMenuItem37";
-            this.toolStripMenuItem37.Size = new System.Drawing.Size(195, 22);
+            this.toolStripMenuItem37.Size = new System.Drawing.Size(278, 30);
             this.toolStripMenuItem37.Text = "Update local database";
             // 
             // toolStripMenuItem38
             // 
             this.toolStripMenuItem38.Name = "toolStripMenuItem38";
-            this.toolStripMenuItem38.Size = new System.Drawing.Size(195, 22);
+            this.toolStripMenuItem38.Size = new System.Drawing.Size(278, 30);
             this.toolStripMenuItem38.Text = "Update nswdb.com list";
             // 
             // toolStripMenuItem39
@@ -2275,7 +2313,7 @@
             this.toolStripSeparator3,
             this.toolStripMenuItem47});
             this.toolStripMenuItem39.Name = "toolStripMenuItem39";
-            this.toolStripMenuItem39.Size = new System.Drawing.Size(47, 20);
+            this.toolStripMenuItem39.Size = new System.Drawing.Size(65, 29);
             this.toolStripMenuItem39.Text = "T&ools";
             // 
             // toolStripMenuItem40
@@ -2284,20 +2322,20 @@
             this.toolStripMenuItem41,
             this.toolStripMenuItem42});
             this.toolStripMenuItem40.Name = "toolStripMenuItem40";
-            this.toolStripMenuItem40.Size = new System.Drawing.Size(158, 22);
+            this.toolStripMenuItem40.Size = new System.Drawing.Size(224, 30);
             this.toolStripMenuItem40.Text = "Trim";
             // 
             // toolStripMenuItem41
             // 
             this.toolStripMenuItem41.Name = "toolStripMenuItem41";
-            this.toolStripMenuItem41.Size = new System.Drawing.Size(142, 22);
+            this.toolStripMenuItem41.Size = new System.Drawing.Size(198, 30);
             this.toolStripMenuItem41.Text = "Selected files";
             this.toolStripMenuItem41.Click += new System.EventHandler(this.toolStripMenuItem41_Click);
             // 
             // toolStripMenuItem42
             // 
             this.toolStripMenuItem42.Name = "toolStripMenuItem42";
-            this.toolStripMenuItem42.Size = new System.Drawing.Size(142, 22);
+            this.toolStripMenuItem42.Size = new System.Drawing.Size(198, 30);
             this.toolStripMenuItem42.Text = "All files";
             this.toolStripMenuItem42.Click += new System.EventHandler(this.toolStripMenuItem42_Click);
             // 
@@ -2307,34 +2345,34 @@
             this.toolStripMenuItemRenameSelectedFilesOnSDCard,
             this.toolStripMenuItemRenameAllFilesOnSDCard});
             this.toolStripMenuItem43.Name = "toolStripMenuItem43";
-            this.toolStripMenuItem43.Size = new System.Drawing.Size(158, 22);
+            this.toolStripMenuItem43.Size = new System.Drawing.Size(224, 30);
             this.toolStripMenuItem43.Text = "Rename";
             // 
             // toolStripMenuItemRenameSelectedFilesOnSDCard
             // 
             this.toolStripMenuItemRenameSelectedFilesOnSDCard.Name = "toolStripMenuItemRenameSelectedFilesOnSDCard";
-            this.toolStripMenuItemRenameSelectedFilesOnSDCard.Size = new System.Drawing.Size(142, 22);
+            this.toolStripMenuItemRenameSelectedFilesOnSDCard.Size = new System.Drawing.Size(198, 30);
             this.toolStripMenuItemRenameSelectedFilesOnSDCard.Text = "Selected files";
             this.toolStripMenuItemRenameSelectedFilesOnSDCard.Click += new System.EventHandler(this.toolStripMenuItemRenameSelectedFilesOnSDCard_Click);
             // 
             // toolStripMenuItemRenameAllFilesOnSDCard
             // 
             this.toolStripMenuItemRenameAllFilesOnSDCard.Name = "toolStripMenuItemRenameAllFilesOnSDCard";
-            this.toolStripMenuItemRenameAllFilesOnSDCard.Size = new System.Drawing.Size(142, 22);
+            this.toolStripMenuItemRenameAllFilesOnSDCard.Size = new System.Drawing.Size(198, 30);
             this.toolStripMenuItemRenameAllFilesOnSDCard.Text = "All files";
             this.toolStripMenuItemRenameAllFilesOnSDCard.Click += new System.EventHandler(this.toolStripMenuItemRenameAllFilesOnSDCard_Click);
             // 
             // toolStripMenuItem46
             // 
             this.toolStripMenuItem46.Name = "toolStripMenuItem46";
-            this.toolStripMenuItem46.Size = new System.Drawing.Size(158, 22);
+            this.toolStripMenuItem46.Size = new System.Drawing.Size(224, 30);
             this.toolStripMenuItem46.Text = "Extract file...";
             this.toolStripMenuItem46.Click += new System.EventHandler(this.toolStripMenuItem46_Click);
             // 
             // toolStripSeparator3
             // 
             this.toolStripSeparator3.Name = "toolStripSeparator3";
-            this.toolStripSeparator3.Size = new System.Drawing.Size(155, 6);
+            this.toolStripSeparator3.Size = new System.Drawing.Size(221, 6);
             // 
             // toolStripMenuItem47
             // 
@@ -2342,30 +2380,31 @@
             this.toolStripMenuItem48,
             this.toolStripMenuItem49});
             this.toolStripMenuItem47.Name = "toolStripMenuItem47";
-            this.toolStripMenuItem47.Size = new System.Drawing.Size(158, 22);
+            this.toolStripMenuItem47.Size = new System.Drawing.Size(224, 30);
             this.toolStripMenuItem47.Text = "Export game list";
             // 
             // toolStripMenuItem48
             // 
             this.toolStripMenuItem48.Name = "toolStripMenuItem48";
-            this.toolStripMenuItem48.Size = new System.Drawing.Size(107, 22);
+            this.toolStripMenuItem48.Size = new System.Drawing.Size(142, 30);
             this.toolStripMenuItem48.Text = "HTML";
             this.toolStripMenuItem48.Click += new System.EventHandler(this.toolStripMenuItem48_Click);
             // 
             // toolStripMenuItem49
             // 
             this.toolStripMenuItem49.Name = "toolStripMenuItem49";
-            this.toolStripMenuItem49.Size = new System.Drawing.Size(107, 22);
+            this.toolStripMenuItem49.Size = new System.Drawing.Size(142, 30);
             this.toolStripMenuItem49.Text = "CSV";
             this.toolStripMenuItem49.Click += new System.EventHandler(this.toolStripMenuItem49_Click);
             // 
             // tabPage3
             // 
             this.tabPage3.Controls.Add(this.panel4);
-            this.tabPage3.Location = new System.Drawing.Point(4, 22);
+            this.tabPage3.Location = new System.Drawing.Point(4, 29);
+            this.tabPage3.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.tabPage3.Name = "tabPage3";
-            this.tabPage3.Padding = new System.Windows.Forms.Padding(3, 3, 3, 3);
-            this.tabPage3.Size = new System.Drawing.Size(1518, 491);
+            this.tabPage3.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.tabPage3.Size = new System.Drawing.Size(2281, 752);
             this.tabPage3.TabIndex = 2;
             this.tabPage3.Text = "Scene releases";
             this.tabPage3.UseVisualStyleBackColor = true;
@@ -2379,16 +2418,18 @@
             this.panel4.Controls.Add(this.OLVSceneList);
             this.panel4.Controls.Add(this.menuStrip3);
             this.panel4.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panel4.Location = new System.Drawing.Point(3, 3);
+            this.panel4.Location = new System.Drawing.Point(4, 5);
+            this.panel4.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.panel4.Name = "panel4";
-            this.panel4.Size = new System.Drawing.Size(1512, 485);
+            this.panel4.Size = new System.Drawing.Size(2273, 742);
             this.panel4.TabIndex = 0;
             // 
             // btnClearFilterScene
             // 
-            this.btnClearFilterScene.Location = new System.Drawing.Point(1434, -1);
+            this.btnClearFilterScene.Location = new System.Drawing.Point(2151, -2);
+            this.btnClearFilterScene.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.btnClearFilterScene.Name = "btnClearFilterScene";
-            this.btnClearFilterScene.Size = new System.Drawing.Size(75, 23);
+            this.btnClearFilterScene.Size = new System.Drawing.Size(112, 35);
             this.btnClearFilterScene.TabIndex = 14;
             this.btnClearFilterScene.Text = "Clear";
             this.btnClearFilterScene.UseVisualStyleBackColor = true;
@@ -2396,18 +2437,20 @@
             // 
             // textBoxFilterScene
             // 
-            this.textBoxFilterScene.Location = new System.Drawing.Point(1159, 1);
+            this.textBoxFilterScene.Location = new System.Drawing.Point(1738, 2);
+            this.textBoxFilterScene.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.textBoxFilterScene.Name = "textBoxFilterScene";
-            this.textBoxFilterScene.Size = new System.Drawing.Size(268, 20);
+            this.textBoxFilterScene.Size = new System.Drawing.Size(400, 26);
             this.textBoxFilterScene.TabIndex = 13;
             this.textBoxFilterScene.TextChanged += new System.EventHandler(this.textBoxFilterScene_TextChanged);
             // 
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(1015, 4);
+            this.label4.Location = new System.Drawing.Point(1522, 6);
+            this.label4.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(32, 13);
+            this.label4.Size = new System.Drawing.Size(48, 20);
             this.label4.TabIndex = 12;
             this.label4.Text = "Filter:";
             // 
@@ -2415,9 +2458,10 @@
             // 
             this.cbxFilterScene.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cbxFilterScene.FormattingEnabled = true;
-            this.cbxFilterScene.Location = new System.Drawing.Point(1050, 0);
+            this.cbxFilterScene.Location = new System.Drawing.Point(1575, 0);
+            this.cbxFilterScene.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.cbxFilterScene.Name = "cbxFilterScene";
-            this.cbxFilterScene.Size = new System.Drawing.Size(102, 21);
+            this.cbxFilterScene.Size = new System.Drawing.Size(151, 28);
             this.cbxFilterScene.TabIndex = 11;
             this.cbxFilterScene.SelectedIndexChanged += new System.EventHandler(this.cbxFilterScene_SelectedIndexChanged);
             // 
@@ -2454,10 +2498,11 @@
             this.OLVSceneList.Dock = System.Windows.Forms.DockStyle.Fill;
             this.OLVSceneList.FullRowSelect = true;
             this.OLVSceneList.GridLines = true;
-            this.OLVSceneList.Location = new System.Drawing.Point(0, 24);
+            this.OLVSceneList.Location = new System.Drawing.Point(0, 35);
+            this.OLVSceneList.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.OLVSceneList.Name = "OLVSceneList";
             this.OLVSceneList.ShowGroups = false;
-            this.OLVSceneList.Size = new System.Drawing.Size(1512, 461);
+            this.OLVSceneList.Size = new System.Drawing.Size(2273, 707);
             this.OLVSceneList.TabIndex = 6;
             this.OLVSceneList.UseCellFormatEvents = true;
             this.OLVSceneList.UseCompatibleStateImageBehavior = false;
@@ -2561,13 +2606,13 @@
             this.contextMenuStripScene.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.copyInfoToClipboardToolStripMenuItem3});
             this.contextMenuStripScene.Name = "contextMenuStripScene";
-            this.contextMenuStripScene.Size = new System.Drawing.Size(194, 26);
+            this.contextMenuStripScene.Size = new System.Drawing.Size(265, 34);
             this.contextMenuStripScene.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenuStripScene_Opening);
             // 
             // copyInfoToClipboardToolStripMenuItem3
             // 
             this.copyInfoToClipboardToolStripMenuItem3.Name = "copyInfoToClipboardToolStripMenuItem3";
-            this.copyInfoToClipboardToolStripMenuItem3.Size = new System.Drawing.Size(193, 22);
+            this.copyInfoToClipboardToolStripMenuItem3.Size = new System.Drawing.Size(264, 30);
             this.copyInfoToClipboardToolStripMenuItem3.Text = "Copy info to clipboard";
             this.copyInfoToClipboardToolStripMenuItem3.Click += new System.EventHandler(this.copyInfoToClipboardToolStripMenuItem3_Click);
             // 
@@ -2584,7 +2629,8 @@
             this.toolStripMenuItem85});
             this.menuStrip3.Location = new System.Drawing.Point(0, 0);
             this.menuStrip3.Name = "menuStrip3";
-            this.menuStrip3.Size = new System.Drawing.Size(1512, 24);
+            this.menuStrip3.Padding = new System.Windows.Forms.Padding(9, 3, 0, 3);
+            this.menuStrip3.Size = new System.Drawing.Size(2273, 35);
             this.menuStrip3.TabIndex = 5;
             this.menuStrip3.Text = "menuStrip3";
             // 
@@ -2598,31 +2644,31 @@
             this.toolStripMenuItem57,
             this.toolStripMenuItem60});
             this.toolStripMenuItem53.Name = "toolStripMenuItem53";
-            this.toolStripMenuItem53.Size = new System.Drawing.Size(50, 20);
+            this.toolStripMenuItem53.Size = new System.Drawing.Size(70, 29);
             this.toolStripMenuItem53.Text = "&Select";
             // 
             // toolStripMenuItem54
             // 
             this.toolStripMenuItem54.Name = "toolStripMenuItem54";
-            this.toolStripMenuItem54.Size = new System.Drawing.Size(154, 22);
+            this.toolStripMenuItem54.Size = new System.Drawing.Size(215, 30);
             this.toolStripMenuItem54.Text = "All";
             // 
             // toolStripMenuItem55
             // 
             this.toolStripMenuItem55.Name = "toolStripMenuItem55";
-            this.toolStripMenuItem55.Size = new System.Drawing.Size(154, 22);
+            this.toolStripMenuItem55.Size = new System.Drawing.Size(215, 30);
             this.toolStripMenuItem55.Text = "None";
             // 
             // toolStripMenuItem56
             // 
             this.toolStripMenuItem56.Name = "toolStripMenuItem56";
-            this.toolStripMenuItem56.Size = new System.Drawing.Size(154, 22);
+            this.toolStripMenuItem56.Size = new System.Drawing.Size(215, 30);
             this.toolStripMenuItem56.Text = "Invert selection";
             // 
             // toolStripSeparator4
             // 
             this.toolStripSeparator4.Name = "toolStripSeparator4";
-            this.toolStripSeparator4.Size = new System.Drawing.Size(151, 6);
+            this.toolStripSeparator4.Size = new System.Drawing.Size(212, 6);
             // 
             // toolStripMenuItem57
             // 
@@ -2630,20 +2676,20 @@
             this.toolStripMenuItem58,
             this.toolStripMenuItem59});
             this.toolStripMenuItem57.Name = "toolStripMenuItem57";
-            this.toolStripMenuItem57.Size = new System.Drawing.Size(154, 22);
+            this.toolStripMenuItem57.Size = new System.Drawing.Size(215, 30);
             this.toolStripMenuItem57.Text = "Local files";
             // 
             // toolStripMenuItem58
             // 
             this.toolStripMenuItem58.Name = "toolStripMenuItem58";
-            this.toolStripMenuItem58.Size = new System.Drawing.Size(190, 22);
+            this.toolStripMenuItem58.Size = new System.Drawing.Size(270, 30);
             this.toolStripMenuItem58.Text = "Items on local files";
             this.toolStripMenuItem58.Click += new System.EventHandler(this.toolStripMenuItem58_Click);
             // 
             // toolStripMenuItem59
             // 
             this.toolStripMenuItem59.Name = "toolStripMenuItem59";
-            this.toolStripMenuItem59.Size = new System.Drawing.Size(190, 22);
+            this.toolStripMenuItem59.Size = new System.Drawing.Size(270, 30);
             this.toolStripMenuItem59.Text = "Items not on localfiles";
             this.toolStripMenuItem59.Click += new System.EventHandler(this.toolStripMenuItem59_Click);
             // 
@@ -2653,20 +2699,20 @@
             this.toolStripMenuItem61,
             this.toolStripMenuItem62});
             this.toolStripMenuItem60.Name = "toolStripMenuItem60";
-            this.toolStripMenuItem60.Size = new System.Drawing.Size(154, 22);
+            this.toolStripMenuItem60.Size = new System.Drawing.Size(215, 30);
             this.toolStripMenuItem60.Text = "SD card";
             // 
             // toolStripMenuItem61
             // 
             this.toolStripMenuItem61.Name = "toolStripMenuItem61";
-            this.toolStripMenuItem61.Size = new System.Drawing.Size(184, 22);
+            this.toolStripMenuItem61.Size = new System.Drawing.Size(265, 30);
             this.toolStripMenuItem61.Text = "Items on SD card";
             this.toolStripMenuItem61.Click += new System.EventHandler(this.toolStripMenuItem61_Click);
             // 
             // toolStripMenuItem62
             // 
             this.toolStripMenuItem62.Name = "toolStripMenuItem62";
-            this.toolStripMenuItem62.Size = new System.Drawing.Size(184, 22);
+            this.toolStripMenuItem62.Size = new System.Drawing.Size(265, 30);
             this.toolStripMenuItem62.Text = "Items not on SD card";
             this.toolStripMenuItem62.Click += new System.EventHandler(this.toolStripMenuItem62_Click);
             // 
@@ -2682,62 +2728,62 @@
             this.toolStripMenuItemGroupFirmwareScene,
             this.toolStripMenuItemGroupTypeScene});
             this.toolStripMenuItem63.Name = "toolStripMenuItem63";
-            this.toolStripMenuItem63.Size = new System.Drawing.Size(69, 20);
+            this.toolStripMenuItem63.Size = new System.Drawing.Size(99, 29);
             this.toolStripMenuItem63.Text = "&Grouping";
             // 
             // toolStripMenuItemGroupNoneScene
             // 
             this.toolStripMenuItemGroupNoneScene.Name = "toolStripMenuItemGroupNoneScene";
-            this.toolStripMenuItemGroupNoneScene.Size = new System.Drawing.Size(148, 22);
+            this.toolStripMenuItemGroupNoneScene.Size = new System.Drawing.Size(208, 30);
             this.toolStripMenuItemGroupNoneScene.Text = "None";
             this.toolStripMenuItemGroupNoneScene.Click += new System.EventHandler(this.toolStripMenuItemGroupNoneScene_Click);
             // 
             // toolStripMenuItemGroupGameTitleScene
             // 
             this.toolStripMenuItemGroupGameTitleScene.Name = "toolStripMenuItemGroupGameTitleScene";
-            this.toolStripMenuItemGroupGameTitleScene.Size = new System.Drawing.Size(148, 22);
+            this.toolStripMenuItemGroupGameTitleScene.Size = new System.Drawing.Size(208, 30);
             this.toolStripMenuItemGroupGameTitleScene.Text = "Game title";
             this.toolStripMenuItemGroupGameTitleScene.Click += new System.EventHandler(this.toolStripMenuItemGroupGameTitleScene_Click);
             // 
             // toolStripMenuItemGroupDeveloperScene
             // 
             this.toolStripMenuItemGroupDeveloperScene.Name = "toolStripMenuItemGroupDeveloperScene";
-            this.toolStripMenuItemGroupDeveloperScene.Size = new System.Drawing.Size(148, 22);
+            this.toolStripMenuItemGroupDeveloperScene.Size = new System.Drawing.Size(208, 30);
             this.toolStripMenuItemGroupDeveloperScene.Text = "Developer";
             this.toolStripMenuItemGroupDeveloperScene.Click += new System.EventHandler(this.toolStripMenuItemGroupDeveloperScene_Click);
             // 
             // regionToolStripMenuItemRegionScene
             // 
             this.regionToolStripMenuItemRegionScene.Name = "regionToolStripMenuItemRegionScene";
-            this.regionToolStripMenuItemRegionScene.Size = new System.Drawing.Size(148, 22);
+            this.regionToolStripMenuItemRegionScene.Size = new System.Drawing.Size(208, 30);
             this.regionToolStripMenuItemRegionScene.Text = "Region";
             this.regionToolStripMenuItemRegionScene.Click += new System.EventHandler(this.regionToolStripMenuItemRegionScene_Click);
             // 
             // releaseGroupToolStripMenuItemReleaseGroupScene
             // 
             this.releaseGroupToolStripMenuItemReleaseGroupScene.Name = "releaseGroupToolStripMenuItemReleaseGroupScene";
-            this.releaseGroupToolStripMenuItemReleaseGroupScene.Size = new System.Drawing.Size(148, 22);
+            this.releaseGroupToolStripMenuItemReleaseGroupScene.Size = new System.Drawing.Size(208, 30);
             this.releaseGroupToolStripMenuItemReleaseGroupScene.Text = "Release group";
             this.releaseGroupToolStripMenuItemReleaseGroupScene.Click += new System.EventHandler(this.releaseGroupToolStripMenuItemReleaseGroupScene_Click);
             // 
             // cartSizeToolStripMenuItemCartSizeScene
             // 
             this.cartSizeToolStripMenuItemCartSizeScene.Name = "cartSizeToolStripMenuItemCartSizeScene";
-            this.cartSizeToolStripMenuItemCartSizeScene.Size = new System.Drawing.Size(148, 22);
+            this.cartSizeToolStripMenuItemCartSizeScene.Size = new System.Drawing.Size(208, 30);
             this.cartSizeToolStripMenuItemCartSizeScene.Text = "Cart size";
             this.cartSizeToolStripMenuItemCartSizeScene.Click += new System.EventHandler(this.cartSizeToolStripMenuItemCartSizeScene_Click);
             // 
             // toolStripMenuItemGroupFirmwareScene
             // 
             this.toolStripMenuItemGroupFirmwareScene.Name = "toolStripMenuItemGroupFirmwareScene";
-            this.toolStripMenuItemGroupFirmwareScene.Size = new System.Drawing.Size(148, 22);
+            this.toolStripMenuItemGroupFirmwareScene.Size = new System.Drawing.Size(208, 30);
             this.toolStripMenuItemGroupFirmwareScene.Text = "Firmware";
             this.toolStripMenuItemGroupFirmwareScene.Click += new System.EventHandler(this.toolStripMenuItemGroupMasterKeyScene_Click);
             // 
             // toolStripMenuItemGroupTypeScene
             // 
             this.toolStripMenuItemGroupTypeScene.Name = "toolStripMenuItemGroupTypeScene";
-            this.toolStripMenuItemGroupTypeScene.Size = new System.Drawing.Size(148, 22);
+            this.toolStripMenuItemGroupTypeScene.Size = new System.Drawing.Size(208, 30);
             this.toolStripMenuItemGroupTypeScene.Text = "Card Type";
             this.toolStripMenuItemGroupTypeScene.Click += new System.EventHandler(this.toolStripMenuItemGroupTypeScene_Click);
             // 
@@ -2747,20 +2793,20 @@
             this.toolStripMenuItem51,
             this.toolStripMenuItem52});
             this.toolStripMenuItem50.Name = "toolStripMenuItem50";
-            this.toolStripMenuItem50.Size = new System.Drawing.Size(41, 20);
+            this.toolStripMenuItem50.Size = new System.Drawing.Size(58, 29);
             this.toolStripMenuItem50.Text = "&Add";
             this.toolStripMenuItem50.Visible = false;
             // 
             // toolStripMenuItem51
             // 
             this.toolStripMenuItem51.Name = "toolStripMenuItem51";
-            this.toolStripMenuItem51.Size = new System.Drawing.Size(116, 22);
+            this.toolStripMenuItem51.Size = new System.Drawing.Size(158, 30);
             this.toolStripMenuItem51.Text = "Files";
             // 
             // toolStripMenuItem52
             // 
             this.toolStripMenuItem52.Name = "toolStripMenuItem52";
-            this.toolStripMenuItem52.Size = new System.Drawing.Size(116, 22);
+            this.toolStripMenuItem52.Size = new System.Drawing.Size(158, 30);
             this.toolStripMenuItem52.Text = "Folder...";
             // 
             // toolStripMenuItem71
@@ -2771,20 +2817,20 @@
             this.toolStripMenuItem73,
             this.toolStripMenuItem76});
             this.toolStripMenuItem71.Name = "toolStripMenuItem71";
-            this.toolStripMenuItem71.Size = new System.Drawing.Size(62, 20);
+            this.toolStripMenuItem71.Size = new System.Drawing.Size(88, 29);
             this.toolStripMenuItem71.Text = "&Remove";
             this.toolStripMenuItem71.Visible = false;
             // 
             // toolStripMenuItem72
             // 
             this.toolStripMenuItem72.Name = "toolStripMenuItem72";
-            this.toolStripMenuItem72.Size = new System.Drawing.Size(149, 22);
+            this.toolStripMenuItem72.Size = new System.Drawing.Size(209, 30);
             this.toolStripMenuItem72.Text = "Selected";
             // 
             // toolStripSeparator5
             // 
             this.toolStripSeparator5.Name = "toolStripSeparator5";
-            this.toolStripSeparator5.Size = new System.Drawing.Size(146, 6);
+            this.toolStripSeparator5.Size = new System.Drawing.Size(206, 6);
             // 
             // toolStripMenuItem73
             // 
@@ -2792,19 +2838,19 @@
             this.toolStripMenuItem74,
             this.toolStripMenuItem75});
             this.toolStripMenuItem73.Name = "toolStripMenuItem73";
-            this.toolStripMenuItem73.Size = new System.Drawing.Size(149, 22);
+            this.toolStripMenuItem73.Size = new System.Drawing.Size(209, 30);
             this.toolStripMenuItem73.Text = "SD card";
             // 
             // toolStripMenuItem74
             // 
             this.toolStripMenuItem74.Name = "toolStripMenuItem74";
-            this.toolStripMenuItem74.Size = new System.Drawing.Size(184, 22);
+            this.toolStripMenuItem74.Size = new System.Drawing.Size(265, 30);
             this.toolStripMenuItem74.Text = "Items on SD card";
             // 
             // toolStripMenuItem75
             // 
             this.toolStripMenuItem75.Name = "toolStripMenuItem75";
-            this.toolStripMenuItem75.Size = new System.Drawing.Size(184, 22);
+            this.toolStripMenuItem75.Size = new System.Drawing.Size(265, 30);
             this.toolStripMenuItem75.Text = "Items not on SD card";
             // 
             // toolStripMenuItem76
@@ -2813,19 +2859,19 @@
             this.toolStripMenuItem77,
             this.toolStripMenuItem78});
             this.toolStripMenuItem76.Name = "toolStripMenuItem76";
-            this.toolStripMenuItem76.Size = new System.Drawing.Size(149, 22);
+            this.toolStripMenuItem76.Size = new System.Drawing.Size(209, 30);
             this.toolStripMenuItem76.Text = "Scene releases";
             // 
             // toolStripMenuItem77
             // 
             this.toolStripMenuItem77.Name = "toolStripMenuItem77";
-            this.toolStripMenuItem77.Size = new System.Drawing.Size(219, 22);
+            this.toolStripMenuItem77.Size = new System.Drawing.Size(316, 30);
             this.toolStripMenuItem77.Text = "Items on Scene releases";
             // 
             // toolStripMenuItem78
             // 
             this.toolStripMenuItem78.Name = "toolStripMenuItem78";
-            this.toolStripMenuItem78.Size = new System.Drawing.Size(219, 22);
+            this.toolStripMenuItem78.Size = new System.Drawing.Size(316, 30);
             this.toolStripMenuItem78.Text = "Items not on Scene releases";
             // 
             // toolStripMenuItem79
@@ -2834,21 +2880,21 @@
             this.toolStripMenuItem80,
             this.toolStripMenuItem81});
             this.toolStripMenuItem79.Name = "toolStripMenuItem79";
-            this.toolStripMenuItem79.Size = new System.Drawing.Size(75, 20);
+            this.toolStripMenuItem79.Size = new System.Drawing.Size(107, 29);
             this.toolStripMenuItem79.Text = "&Transfer to";
             this.toolStripMenuItem79.Visible = false;
             // 
             // toolStripMenuItem80
             // 
             this.toolStripMenuItem80.Name = "toolStripMenuItem80";
-            this.toolStripMenuItem80.Size = new System.Drawing.Size(116, 22);
+            this.toolStripMenuItem80.Size = new System.Drawing.Size(158, 30);
             this.toolStripMenuItem80.Text = "SD card";
             this.toolStripMenuItem80.Visible = false;
             // 
             // toolStripMenuItem81
             // 
             this.toolStripMenuItem81.Name = "toolStripMenuItem81";
-            this.toolStripMenuItem81.Size = new System.Drawing.Size(116, 22);
+            this.toolStripMenuItem81.Size = new System.Drawing.Size(158, 30);
             this.toolStripMenuItem81.Text = "Folder...";
             // 
             // toolStripMenuItem82
@@ -2857,20 +2903,20 @@
             this.toolStripMenuItem83,
             this.toolStripMenuItem84});
             this.toolStripMenuItem82.Name = "toolStripMenuItem82";
-            this.toolStripMenuItem82.Size = new System.Drawing.Size(45, 20);
+            this.toolStripMenuItem82.Size = new System.Drawing.Size(64, 29);
             this.toolStripMenuItem82.Text = "&Infos";
             this.toolStripMenuItem82.Visible = false;
             // 
             // toolStripMenuItem83
             // 
             this.toolStripMenuItem83.Name = "toolStripMenuItem83";
-            this.toolStripMenuItem83.Size = new System.Drawing.Size(195, 22);
+            this.toolStripMenuItem83.Size = new System.Drawing.Size(278, 30);
             this.toolStripMenuItem83.Text = "Update local database";
             // 
             // toolStripMenuItem84
             // 
             this.toolStripMenuItem84.Name = "toolStripMenuItem84";
-            this.toolStripMenuItem84.Size = new System.Drawing.Size(195, 22);
+            this.toolStripMenuItem84.Size = new System.Drawing.Size(278, 30);
             this.toolStripMenuItem84.Text = "Update nswdb.com list";
             // 
             // toolStripMenuItem85
@@ -2882,7 +2928,7 @@
             this.toolStripSeparator6,
             this.toolStripMenuItem93});
             this.toolStripMenuItem85.Name = "toolStripMenuItem85";
-            this.toolStripMenuItem85.Size = new System.Drawing.Size(47, 20);
+            this.toolStripMenuItem85.Size = new System.Drawing.Size(65, 29);
             this.toolStripMenuItem85.Text = "T&ools";
             this.toolStripMenuItem85.Visible = false;
             // 
@@ -2892,19 +2938,19 @@
             this.toolStripMenuItem87,
             this.toolStripMenuItem88});
             this.toolStripMenuItem86.Name = "toolStripMenuItem86";
-            this.toolStripMenuItem86.Size = new System.Drawing.Size(158, 22);
+            this.toolStripMenuItem86.Size = new System.Drawing.Size(224, 30);
             this.toolStripMenuItem86.Text = "Trim";
             // 
             // toolStripMenuItem87
             // 
             this.toolStripMenuItem87.Name = "toolStripMenuItem87";
-            this.toolStripMenuItem87.Size = new System.Drawing.Size(142, 22);
+            this.toolStripMenuItem87.Size = new System.Drawing.Size(198, 30);
             this.toolStripMenuItem87.Text = "Selected files";
             // 
             // toolStripMenuItem88
             // 
             this.toolStripMenuItem88.Name = "toolStripMenuItem88";
-            this.toolStripMenuItem88.Size = new System.Drawing.Size(142, 22);
+            this.toolStripMenuItem88.Size = new System.Drawing.Size(198, 30);
             this.toolStripMenuItem88.Text = "All files";
             // 
             // toolStripMenuItem89
@@ -2913,31 +2959,31 @@
             this.toolStripMenuItem90,
             this.toolStripMenuItem91});
             this.toolStripMenuItem89.Name = "toolStripMenuItem89";
-            this.toolStripMenuItem89.Size = new System.Drawing.Size(158, 22);
+            this.toolStripMenuItem89.Size = new System.Drawing.Size(224, 30);
             this.toolStripMenuItem89.Text = "Rename";
             // 
             // toolStripMenuItem90
             // 
             this.toolStripMenuItem90.Name = "toolStripMenuItem90";
-            this.toolStripMenuItem90.Size = new System.Drawing.Size(142, 22);
+            this.toolStripMenuItem90.Size = new System.Drawing.Size(198, 30);
             this.toolStripMenuItem90.Text = "All files";
             // 
             // toolStripMenuItem91
             // 
             this.toolStripMenuItem91.Name = "toolStripMenuItem91";
-            this.toolStripMenuItem91.Size = new System.Drawing.Size(142, 22);
+            this.toolStripMenuItem91.Size = new System.Drawing.Size(198, 30);
             this.toolStripMenuItem91.Text = "Selected files";
             // 
             // toolStripMenuItem92
             // 
             this.toolStripMenuItem92.Name = "toolStripMenuItem92";
-            this.toolStripMenuItem92.Size = new System.Drawing.Size(158, 22);
+            this.toolStripMenuItem92.Size = new System.Drawing.Size(224, 30);
             this.toolStripMenuItem92.Text = "Extract file...";
             // 
             // toolStripSeparator6
             // 
             this.toolStripSeparator6.Name = "toolStripSeparator6";
-            this.toolStripSeparator6.Size = new System.Drawing.Size(155, 6);
+            this.toolStripSeparator6.Size = new System.Drawing.Size(221, 6);
             // 
             // toolStripMenuItem93
             // 
@@ -2945,29 +2991,30 @@
             this.toolStripMenuItem94,
             this.toolStripMenuItem95});
             this.toolStripMenuItem93.Name = "toolStripMenuItem93";
-            this.toolStripMenuItem93.Size = new System.Drawing.Size(158, 22);
+            this.toolStripMenuItem93.Size = new System.Drawing.Size(224, 30);
             this.toolStripMenuItem93.Text = "Export game list";
             // 
             // toolStripMenuItem94
             // 
             this.toolStripMenuItem94.Name = "toolStripMenuItem94";
-            this.toolStripMenuItem94.Size = new System.Drawing.Size(107, 22);
+            this.toolStripMenuItem94.Size = new System.Drawing.Size(142, 30);
             this.toolStripMenuItem94.Text = "HTML";
             // 
             // toolStripMenuItem95
             // 
             this.toolStripMenuItem95.Name = "toolStripMenuItem95";
-            this.toolStripMenuItem95.Size = new System.Drawing.Size(107, 22);
+            this.toolStripMenuItem95.Size = new System.Drawing.Size(142, 30);
             this.toolStripMenuItem95.Text = "CSV";
             // 
             // tabPage4
             // 
             this.tabPage4.Controls.Add(this.panel10);
             this.tabPage4.Controls.Add(this.panel11);
-            this.tabPage4.Location = new System.Drawing.Point(4, 22);
+            this.tabPage4.Location = new System.Drawing.Point(4, 29);
+            this.tabPage4.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.tabPage4.Name = "tabPage4";
-            this.tabPage4.Padding = new System.Windows.Forms.Padding(3, 3, 3, 3);
-            this.tabPage4.Size = new System.Drawing.Size(1518, 491);
+            this.tabPage4.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.tabPage4.Size = new System.Drawing.Size(2281, 752);
             this.tabPage4.TabIndex = 3;
             this.tabPage4.Text = "E-shop files";
             this.tabPage4.UseVisualStyleBackColor = true;
@@ -2976,9 +3023,10 @@
             // 
             this.panel10.Controls.Add(this.OLVEshop);
             this.panel10.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panel10.Location = new System.Drawing.Point(3, 31);
+            this.panel10.Location = new System.Drawing.Point(4, 48);
+            this.panel10.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.panel10.Name = "panel10";
-            this.panel10.Size = new System.Drawing.Size(1512, 457);
+            this.panel10.Size = new System.Drawing.Size(2273, 699);
             this.panel10.TabIndex = 11;
             // 
             // OLVEshop
@@ -3031,9 +3079,10 @@
             this.OLVEshop.FullRowSelect = true;
             this.OLVEshop.GridLines = true;
             this.OLVEshop.Location = new System.Drawing.Point(0, 0);
+            this.OLVEshop.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.OLVEshop.Name = "OLVEshop";
             this.OLVEshop.ShowGroups = false;
-            this.OLVEshop.Size = new System.Drawing.Size(1512, 457);
+            this.OLVEshop.Size = new System.Drawing.Size(2273, 699);
             this.OLVEshop.TabIndex = 3;
             this.OLVEshop.UseCellFormatEvents = true;
             this.OLVEshop.UseCompatibleStateImageBehavior = false;
@@ -3183,20 +3232,20 @@
             this.toolStripMenuItem97Eshop,
             this.deleteSelectedFilesToolStripMenuItemEshop});
             this.contextMenuEShopList.Name = "contextMenuStripSDCard";
-            this.contextMenuEShopList.Size = new System.Drawing.Size(277, 204);
+            this.contextMenuEShopList.Size = new System.Drawing.Size(390, 268);
             this.contextMenuEShopList.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenuStripEShop_Opening);
             // 
             // toolStripMenuItemEShopShowInExplorer
             // 
             this.toolStripMenuItemEShopShowInExplorer.Name = "toolStripMenuItemEShopShowInExplorer";
-            this.toolStripMenuItemEShopShowInExplorer.Size = new System.Drawing.Size(276, 22);
+            this.toolStripMenuItemEShopShowInExplorer.Size = new System.Drawing.Size(389, 30);
             this.toolStripMenuItemEShopShowInExplorer.Text = "Show in explorer";
             this.toolStripMenuItemEShopShowInExplorer.Click += new System.EventHandler(this.toolStripMenuItemEShopShowInExplorer_Click);
             // 
             // toolStripMenuItemEShopUpdateInfo
             // 
             this.toolStripMenuItemEShopUpdateInfo.Name = "toolStripMenuItemEShopUpdateInfo";
-            this.toolStripMenuItemEShopUpdateInfo.Size = new System.Drawing.Size(276, 22);
+            this.toolStripMenuItemEShopUpdateInfo.Size = new System.Drawing.Size(389, 30);
             this.toolStripMenuItemEShopUpdateInfo.Text = "Update info";
             this.toolStripMenuItemEShopUpdateInfo.Visible = false;
             this.toolStripMenuItemEShopUpdateInfo.Click += new System.EventHandler(this.toolStripMenuItemEShopUpdateInfo_Click);
@@ -3204,19 +3253,19 @@
             // toolStripSeparator9
             // 
             this.toolStripSeparator9.Name = "toolStripSeparator9";
-            this.toolStripSeparator9.Size = new System.Drawing.Size(273, 6);
+            this.toolStripSeparator9.Size = new System.Drawing.Size(386, 6);
             // 
             // toolStripMenuItemEShopAutoRename
             // 
             this.toolStripMenuItemEShopAutoRename.Name = "toolStripMenuItemEShopAutoRename";
-            this.toolStripMenuItemEShopAutoRename.Size = new System.Drawing.Size(276, 22);
+            this.toolStripMenuItemEShopAutoRename.Size = new System.Drawing.Size(389, 30);
             this.toolStripMenuItemEShopAutoRename.Text = "Auto rename files";
             this.toolStripMenuItemEShopAutoRename.Click += new System.EventHandler(this.toolStripMenuItemEShopAutoRename_Click);
             // 
             // toolStripSeparator10
             // 
             this.toolStripSeparator10.Name = "toolStripSeparator10";
-            this.toolStripSeparator10.Size = new System.Drawing.Size(273, 6);
+            this.toolStripSeparator10.Size = new System.Drawing.Size(386, 6);
             // 
             // toolStripMenuItemEShopCopyToFolder
             // 
@@ -3224,20 +3273,20 @@
             this.sDCardToolStripMenuItem4,
             this.folderToolStripMenuItem5});
             this.toolStripMenuItemEShopCopyToFolder.Name = "toolStripMenuItemEShopCopyToFolder";
-            this.toolStripMenuItemEShopCopyToFolder.Size = new System.Drawing.Size(276, 22);
+            this.toolStripMenuItemEShopCopyToFolder.Size = new System.Drawing.Size(389, 30);
             this.toolStripMenuItemEShopCopyToFolder.Text = "Copy files to";
             // 
             // sDCardToolStripMenuItem4
             // 
             this.sDCardToolStripMenuItem4.Name = "sDCardToolStripMenuItem4";
-            this.sDCardToolStripMenuItem4.Size = new System.Drawing.Size(116, 22);
+            this.sDCardToolStripMenuItem4.Size = new System.Drawing.Size(158, 30);
             this.sDCardToolStripMenuItem4.Text = "SD card";
             this.sDCardToolStripMenuItem4.Click += new System.EventHandler(this.sDCardToolStripMenuItem4_Click);
             // 
             // folderToolStripMenuItem5
             // 
             this.folderToolStripMenuItem5.Name = "folderToolStripMenuItem5";
-            this.folderToolStripMenuItem5.Size = new System.Drawing.Size(116, 22);
+            this.folderToolStripMenuItem5.Size = new System.Drawing.Size(158, 30);
             this.folderToolStripMenuItem5.Text = "Folder...";
             this.folderToolStripMenuItem5.Click += new System.EventHandler(this.folderToolStripMenuItem5_Click);
             // 
@@ -3247,51 +3296,51 @@
             this.sDCardToolStripMenuItem5,
             this.folderToolStripMenuItem6});
             this.toolStripMenuItemEShopMoveToFolder.Name = "toolStripMenuItemEShopMoveToFolder";
-            this.toolStripMenuItemEShopMoveToFolder.Size = new System.Drawing.Size(276, 22);
+            this.toolStripMenuItemEShopMoveToFolder.Size = new System.Drawing.Size(389, 30);
             this.toolStripMenuItemEShopMoveToFolder.Text = "Move files to";
             // 
             // sDCardToolStripMenuItem5
             // 
             this.sDCardToolStripMenuItem5.Name = "sDCardToolStripMenuItem5";
-            this.sDCardToolStripMenuItem5.Size = new System.Drawing.Size(116, 22);
+            this.sDCardToolStripMenuItem5.Size = new System.Drawing.Size(158, 30);
             this.sDCardToolStripMenuItem5.Text = "SD card";
             this.sDCardToolStripMenuItem5.Click += new System.EventHandler(this.sDCardToolStripMenuItem5_Click);
             // 
             // folderToolStripMenuItem6
             // 
             this.folderToolStripMenuItem6.Name = "folderToolStripMenuItem6";
-            this.folderToolStripMenuItem6.Size = new System.Drawing.Size(116, 22);
+            this.folderToolStripMenuItem6.Size = new System.Drawing.Size(158, 30);
             this.folderToolStripMenuItem6.Text = "Folder...";
             this.folderToolStripMenuItem6.Click += new System.EventHandler(this.folderToolStripMenuItem6_Click);
             // 
             // toolStripMenuItem64
             // 
             this.toolStripMenuItem64.Name = "toolStripMenuItem64";
-            this.toolStripMenuItem64.Size = new System.Drawing.Size(273, 6);
+            this.toolStripMenuItem64.Size = new System.Drawing.Size(386, 6);
             // 
             // copyInfoToClipboardToolStripMenuItem
             // 
             this.copyInfoToClipboardToolStripMenuItem.Name = "copyInfoToClipboardToolStripMenuItem";
-            this.copyInfoToClipboardToolStripMenuItem.Size = new System.Drawing.Size(276, 22);
+            this.copyInfoToClipboardToolStripMenuItem.Size = new System.Drawing.Size(389, 30);
             this.copyInfoToClipboardToolStripMenuItem.Text = "Copy info to clipboard";
             this.copyInfoToClipboardToolStripMenuItem.Click += new System.EventHandler(this.copyInfoToClipboardToolStripMenuItem_Click);
             // 
             // updateGameInfoFromWebToolStripMenuItemEshop
             // 
             this.updateGameInfoFromWebToolStripMenuItemEshop.Name = "updateGameInfoFromWebToolStripMenuItemEshop";
-            this.updateGameInfoFromWebToolStripMenuItemEshop.Size = new System.Drawing.Size(276, 22);
+            this.updateGameInfoFromWebToolStripMenuItemEshop.Size = new System.Drawing.Size(389, 30);
             this.updateGameInfoFromWebToolStripMenuItemEshop.Text = "Update game info from Web";
             this.updateGameInfoFromWebToolStripMenuItemEshop.Click += new System.EventHandler(this.updateGameInfoFromWebToolStripMenuItemEshop_Click);
             // 
             // toolStripMenuItem97Eshop
             // 
             this.toolStripMenuItem97Eshop.Name = "toolStripMenuItem97Eshop";
-            this.toolStripMenuItem97Eshop.Size = new System.Drawing.Size(273, 6);
+            this.toolStripMenuItem97Eshop.Size = new System.Drawing.Size(386, 6);
             // 
             // deleteSelectedFilesToolStripMenuItemEshop
             // 
             this.deleteSelectedFilesToolStripMenuItemEshop.Name = "deleteSelectedFilesToolStripMenuItemEshop";
-            this.deleteSelectedFilesToolStripMenuItemEshop.Size = new System.Drawing.Size(276, 22);
+            this.deleteSelectedFilesToolStripMenuItemEshop.Size = new System.Drawing.Size(389, 30);
             this.deleteSelectedFilesToolStripMenuItemEshop.Text = "Delete selected files (erases from disk!)";
             this.deleteSelectedFilesToolStripMenuItemEshop.Click += new System.EventHandler(this.deleteSelectedFilesToolStripMenuItemEshop_Click);
             // 
@@ -3300,9 +3349,10 @@
             this.panel11.Controls.Add(this.panel13);
             this.panel11.Controls.Add(this.panel12);
             this.panel11.Dock = System.Windows.Forms.DockStyle.Top;
-            this.panel11.Location = new System.Drawing.Point(3, 3);
+            this.panel11.Location = new System.Drawing.Point(4, 5);
+            this.panel11.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.panel11.Name = "panel11";
-            this.panel11.Size = new System.Drawing.Size(1512, 28);
+            this.panel11.Size = new System.Drawing.Size(2273, 43);
             this.panel11.TabIndex = 10;
             // 
             // panel13
@@ -3315,9 +3365,10 @@
             this.panel13.Controls.Add(this.label5);
             this.panel13.Controls.Add(this.cbxFilterEshop);
             this.panel13.Dock = System.Windows.Forms.DockStyle.Right;
-            this.panel13.Location = new System.Drawing.Point(799, 0);
+            this.panel13.Location = new System.Drawing.Point(1203, 0);
+            this.panel13.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.panel13.Name = "panel13";
-            this.panel13.Size = new System.Drawing.Size(713, 28);
+            this.panel13.Size = new System.Drawing.Size(1070, 43);
             this.panel13.TabIndex = 1;
             // 
             // cbBaseGame
@@ -3325,9 +3376,10 @@
             this.cbBaseGame.AutoSize = true;
             this.cbBaseGame.Checked = true;
             this.cbBaseGame.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.cbBaseGame.Location = new System.Drawing.Point(126, 5);
+            this.cbBaseGame.Location = new System.Drawing.Point(189, 8);
+            this.cbBaseGame.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.cbBaseGame.Name = "cbBaseGame";
-            this.cbBaseGame.Size = new System.Drawing.Size(79, 17);
+            this.cbBaseGame.Size = new System.Drawing.Size(116, 24);
             this.cbBaseGame.TabIndex = 20;
             this.cbBaseGame.Text = "Base game";
             this.cbBaseGame.UseVisualStyleBackColor = true;
@@ -3338,9 +3390,10 @@
             this.cbUpdates.AutoSize = true;
             this.cbUpdates.Checked = true;
             this.cbUpdates.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.cbUpdates.Location = new System.Drawing.Point(58, 5);
+            this.cbUpdates.Location = new System.Drawing.Point(87, 8);
+            this.cbUpdates.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.cbUpdates.Name = "cbUpdates";
-            this.cbUpdates.Size = new System.Drawing.Size(61, 17);
+            this.cbUpdates.Size = new System.Drawing.Size(88, 24);
             this.cbUpdates.TabIndex = 19;
             this.cbUpdates.Text = "Update";
             this.cbUpdates.UseVisualStyleBackColor = true;
@@ -3349,9 +3402,10 @@
             // cbDLC
             // 
             this.cbDLC.AutoSize = true;
-            this.cbDLC.Location = new System.Drawing.Point(4, 5);
+            this.cbDLC.Location = new System.Drawing.Point(6, 8);
+            this.cbDLC.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.cbDLC.Name = "cbDLC";
-            this.cbDLC.Size = new System.Drawing.Size(47, 17);
+            this.cbDLC.Size = new System.Drawing.Size(67, 24);
             this.cbDLC.TabIndex = 18;
             this.cbDLC.Text = "DLC";
             this.cbDLC.UseVisualStyleBackColor = true;
@@ -3359,9 +3413,10 @@
             // 
             // btnClearFilterEShop
             // 
-            this.btnClearFilterEShop.Location = new System.Drawing.Point(634, 2);
+            this.btnClearFilterEShop.Location = new System.Drawing.Point(951, 3);
+            this.btnClearFilterEShop.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.btnClearFilterEShop.Name = "btnClearFilterEShop";
-            this.btnClearFilterEShop.Size = new System.Drawing.Size(75, 23);
+            this.btnClearFilterEShop.Size = new System.Drawing.Size(112, 35);
             this.btnClearFilterEShop.TabIndex = 17;
             this.btnClearFilterEShop.Text = "Clear";
             this.btnClearFilterEShop.UseVisualStyleBackColor = true;
@@ -3369,9 +3424,10 @@
             // 
             // textBoxFilterEShop
             // 
-            this.textBoxFilterEShop.Location = new System.Drawing.Point(359, 4);
+            this.textBoxFilterEShop.Location = new System.Drawing.Point(538, 6);
+            this.textBoxFilterEShop.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.textBoxFilterEShop.Name = "textBoxFilterEShop";
-            this.textBoxFilterEShop.Size = new System.Drawing.Size(268, 20);
+            this.textBoxFilterEShop.Size = new System.Drawing.Size(400, 26);
             this.textBoxFilterEShop.TabIndex = 16;
             this.textBoxFilterEShop.TextChanged += new System.EventHandler(this.textBoxFilterEShop_TextChanged);
             // 
@@ -3379,9 +3435,10 @@
             // 
             this.label5.AutoSize = true;
             this.label5.BackColor = System.Drawing.SystemColors.Window;
-            this.label5.Location = new System.Drawing.Point(215, 7);
+            this.label5.Location = new System.Drawing.Point(322, 11);
+            this.label5.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(32, 13);
+            this.label5.Size = new System.Drawing.Size(48, 20);
             this.label5.TabIndex = 15;
             this.label5.Text = "Filter:";
             // 
@@ -3389,9 +3446,10 @@
             // 
             this.cbxFilterEshop.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cbxFilterEshop.FormattingEnabled = true;
-            this.cbxFilterEshop.Location = new System.Drawing.Point(250, 3);
+            this.cbxFilterEshop.Location = new System.Drawing.Point(375, 5);
+            this.cbxFilterEshop.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.cbxFilterEshop.Name = "cbxFilterEshop";
-            this.cbxFilterEshop.Size = new System.Drawing.Size(102, 21);
+            this.cbxFilterEshop.Size = new System.Drawing.Size(151, 28);
             this.cbxFilterEshop.TabIndex = 14;
             this.cbxFilterEshop.SelectedIndexChanged += new System.EventHandler(this.cbxFilterEshop_SelectedIndexChanged);
             // 
@@ -3400,8 +3458,9 @@
             this.panel12.Controls.Add(this.menuEShop);
             this.panel12.Dock = System.Windows.Forms.DockStyle.Left;
             this.panel12.Location = new System.Drawing.Point(0, 0);
+            this.panel12.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.panel12.Name = "panel12";
-            this.panel12.Size = new System.Drawing.Size(777, 28);
+            this.panel12.Size = new System.Drawing.Size(1166, 43);
             this.panel12.TabIndex = 0;
             // 
             // menuEShop
@@ -3415,7 +3474,8 @@
             this.toolStripMenuItem24});
             this.menuEShop.Location = new System.Drawing.Point(0, 0);
             this.menuEShop.Name = "menuEShop";
-            this.menuEShop.Size = new System.Drawing.Size(777, 24);
+            this.menuEShop.Padding = new System.Windows.Forms.Padding(9, 3, 0, 3);
+            this.menuEShop.Size = new System.Drawing.Size(1166, 35);
             this.menuEShop.TabIndex = 9;
             this.menuEShop.Text = "menuStrip2";
             // 
@@ -3425,20 +3485,20 @@
             this.filesToolStripMenuItem1,
             this.folderToolStripMenuItem4});
             this.addToolStripMenuItemAddFolderEShop.Name = "addToolStripMenuItemAddFolderEShop";
-            this.addToolStripMenuItemAddFolderEShop.Size = new System.Drawing.Size(41, 20);
+            this.addToolStripMenuItemAddFolderEShop.Size = new System.Drawing.Size(58, 29);
             this.addToolStripMenuItemAddFolderEShop.Text = "Add";
             // 
             // filesToolStripMenuItem1
             // 
             this.filesToolStripMenuItem1.Name = "filesToolStripMenuItem1";
-            this.filesToolStripMenuItem1.Size = new System.Drawing.Size(116, 22);
+            this.filesToolStripMenuItem1.Size = new System.Drawing.Size(158, 30);
             this.filesToolStripMenuItem1.Text = "Files...";
             this.filesToolStripMenuItem1.Click += new System.EventHandler(this.filesToolStripMenuItem1_Click);
             // 
             // folderToolStripMenuItem4
             // 
             this.folderToolStripMenuItem4.Name = "folderToolStripMenuItem4";
-            this.folderToolStripMenuItem4.Size = new System.Drawing.Size(116, 22);
+            this.folderToolStripMenuItem4.Size = new System.Drawing.Size(158, 30);
             this.folderToolStripMenuItem4.Text = "Folder...";
             this.folderToolStripMenuItem4.Click += new System.EventHandler(this.folderToolStripMenuItem4_Click);
             // 
@@ -3454,34 +3514,34 @@
             this.toolStripMenuItem97,
             this.outdatedToolStripMenuItem});
             this.toolStripMenuItemSelectEshop.Name = "toolStripMenuItemSelectEshop";
-            this.toolStripMenuItemSelectEshop.Size = new System.Drawing.Size(50, 20);
+            this.toolStripMenuItemSelectEshop.Size = new System.Drawing.Size(70, 29);
             this.toolStripMenuItemSelectEshop.Text = "&Select";
             // 
             // toolStripMenuItemSelectAllEshop
             // 
             this.toolStripMenuItemSelectAllEshop.Name = "toolStripMenuItemSelectAllEshop";
-            this.toolStripMenuItemSelectAllEshop.Size = new System.Drawing.Size(169, 22);
+            this.toolStripMenuItemSelectAllEshop.Size = new System.Drawing.Size(241, 30);
             this.toolStripMenuItemSelectAllEshop.Text = "All";
             this.toolStripMenuItemSelectAllEshop.Click += new System.EventHandler(this.toolStripMenuItemSelectAllEshop_Click);
             // 
             // toolStripMenuItemSelectNoneEShop
             // 
             this.toolStripMenuItemSelectNoneEShop.Name = "toolStripMenuItemSelectNoneEShop";
-            this.toolStripMenuItemSelectNoneEShop.Size = new System.Drawing.Size(169, 22);
+            this.toolStripMenuItemSelectNoneEShop.Size = new System.Drawing.Size(241, 30);
             this.toolStripMenuItemSelectNoneEShop.Text = "None";
             this.toolStripMenuItemSelectNoneEShop.Click += new System.EventHandler(this.toolStripMenuItemSelectNoneEShop_Click);
             // 
             // toolStripMenuItemSelectInvertEShop
             // 
             this.toolStripMenuItemSelectInvertEShop.Name = "toolStripMenuItemSelectInvertEShop";
-            this.toolStripMenuItemSelectInvertEShop.Size = new System.Drawing.Size(169, 22);
+            this.toolStripMenuItemSelectInvertEShop.Size = new System.Drawing.Size(241, 30);
             this.toolStripMenuItemSelectInvertEShop.Text = "Invert selection";
             this.toolStripMenuItemSelectInvertEShop.Click += new System.EventHandler(this.toolStripMenuItemSelectInvertEShop_Click);
             // 
             // toolStripSeparator7
             // 
             this.toolStripSeparator7.Name = "toolStripSeparator7";
-            this.toolStripSeparator7.Size = new System.Drawing.Size(166, 6);
+            this.toolStripSeparator7.Size = new System.Drawing.Size(238, 6);
             // 
             // toolStripMenuItemSelectSDCardEShop
             // 
@@ -3489,20 +3549,20 @@
             this.toolStripMenuItemSelectSDCardItemsOnSDEShop,
             this.toolStripMenuItemSelectSDCardItemsNotOnSDCardEShop});
             this.toolStripMenuItemSelectSDCardEShop.Name = "toolStripMenuItemSelectSDCardEShop";
-            this.toolStripMenuItemSelectSDCardEShop.Size = new System.Drawing.Size(169, 22);
+            this.toolStripMenuItemSelectSDCardEShop.Size = new System.Drawing.Size(241, 30);
             this.toolStripMenuItemSelectSDCardEShop.Text = "SD card";
             // 
             // toolStripMenuItemSelectSDCardItemsOnSDEShop
             // 
             this.toolStripMenuItemSelectSDCardItemsOnSDEShop.Name = "toolStripMenuItemSelectSDCardItemsOnSDEShop";
-            this.toolStripMenuItemSelectSDCardItemsOnSDEShop.Size = new System.Drawing.Size(184, 22);
+            this.toolStripMenuItemSelectSDCardItemsOnSDEShop.Size = new System.Drawing.Size(265, 30);
             this.toolStripMenuItemSelectSDCardItemsOnSDEShop.Text = "Items on SD card";
             this.toolStripMenuItemSelectSDCardItemsOnSDEShop.Click += new System.EventHandler(this.toolStripMenuItemSelectSDCardItemsOnSDEShop_Click);
             // 
             // toolStripMenuItemSelectSDCardItemsNotOnSDCardEShop
             // 
             this.toolStripMenuItemSelectSDCardItemsNotOnSDCardEShop.Name = "toolStripMenuItemSelectSDCardItemsNotOnSDCardEShop";
-            this.toolStripMenuItemSelectSDCardItemsNotOnSDCardEShop.Size = new System.Drawing.Size(184, 22);
+            this.toolStripMenuItemSelectSDCardItemsNotOnSDCardEShop.Size = new System.Drawing.Size(265, 30);
             this.toolStripMenuItemSelectSDCardItemsNotOnSDCardEShop.Text = "Items not on SD card";
             this.toolStripMenuItemSelectSDCardItemsNotOnSDCardEShop.Click += new System.EventHandler(this.toolStripMenuItemSelectSDCardItemsNotOnSDCardEShop_Click);
             // 
@@ -3512,32 +3572,32 @@
             this.toolStripMenuItemSelectSceneOnEShop,
             this.toolStripMenuItemSelectSceneNotOnEShop});
             this.toolStripMenuItemSelectSceneEShop.Name = "toolStripMenuItemSelectSceneEShop";
-            this.toolStripMenuItemSelectSceneEShop.Size = new System.Drawing.Size(169, 22);
+            this.toolStripMenuItemSelectSceneEShop.Size = new System.Drawing.Size(241, 30);
             this.toolStripMenuItemSelectSceneEShop.Text = "Scene releases";
             this.toolStripMenuItemSelectSceneEShop.Visible = false;
             // 
             // toolStripMenuItemSelectSceneOnEShop
             // 
             this.toolStripMenuItemSelectSceneOnEShop.Name = "toolStripMenuItemSelectSceneOnEShop";
-            this.toolStripMenuItemSelectSceneOnEShop.Size = new System.Drawing.Size(219, 22);
+            this.toolStripMenuItemSelectSceneOnEShop.Size = new System.Drawing.Size(316, 30);
             this.toolStripMenuItemSelectSceneOnEShop.Text = "Items on Scene releases";
             this.toolStripMenuItemSelectSceneOnEShop.Click += new System.EventHandler(this.toolStripMenuItemSelectSceneOnEShop_Click);
             // 
             // toolStripMenuItemSelectSceneNotOnEShop
             // 
             this.toolStripMenuItemSelectSceneNotOnEShop.Name = "toolStripMenuItemSelectSceneNotOnEShop";
-            this.toolStripMenuItemSelectSceneNotOnEShop.Size = new System.Drawing.Size(219, 22);
+            this.toolStripMenuItemSelectSceneNotOnEShop.Size = new System.Drawing.Size(316, 30);
             this.toolStripMenuItemSelectSceneNotOnEShop.Text = "Items not on Scene releases";
             // 
             // toolStripMenuItem97
             // 
             this.toolStripMenuItem97.Name = "toolStripMenuItem97";
-            this.toolStripMenuItem97.Size = new System.Drawing.Size(166, 6);
+            this.toolStripMenuItem97.Size = new System.Drawing.Size(238, 6);
             // 
             // outdatedToolStripMenuItem
             // 
             this.outdatedToolStripMenuItem.Name = "outdatedToolStripMenuItem";
-            this.outdatedToolStripMenuItem.Size = new System.Drawing.Size(169, 22);
+            this.outdatedToolStripMenuItem.Size = new System.Drawing.Size(241, 30);
             this.outdatedToolStripMenuItem.Text = "Outdated updates";
             this.outdatedToolStripMenuItem.Click += new System.EventHandler(this.outdatedToolStripMenuItem_Click);
             // 
@@ -3549,34 +3609,34 @@
             this.toolStripMenuItemGroupingDeveloperEShop,
             this.toolStripMenuItemGroupingMasterKeyEShop});
             this.toolStripMenuItem22.Name = "toolStripMenuItem22";
-            this.toolStripMenuItem22.Size = new System.Drawing.Size(69, 20);
+            this.toolStripMenuItem22.Size = new System.Drawing.Size(99, 29);
             this.toolStripMenuItem22.Text = "&Grouping";
             // 
             // toolStripMenuItemGroupingNoneEShop
             // 
             this.toolStripMenuItemGroupingNoneEShop.Name = "toolStripMenuItemGroupingNoneEShop";
-            this.toolStripMenuItemGroupingNoneEShop.Size = new System.Drawing.Size(172, 22);
+            this.toolStripMenuItemGroupingNoneEShop.Size = new System.Drawing.Size(243, 30);
             this.toolStripMenuItemGroupingNoneEShop.Text = "None";
             this.toolStripMenuItemGroupingNoneEShop.Click += new System.EventHandler(this.toolStripMenuItemGroupingNoneEShop_Click);
             // 
             // toolStripMenuItemGroupingGameTitleEShop
             // 
             this.toolStripMenuItemGroupingGameTitleEShop.Name = "toolStripMenuItemGroupingGameTitleEShop";
-            this.toolStripMenuItemGroupingGameTitleEShop.Size = new System.Drawing.Size(172, 22);
+            this.toolStripMenuItemGroupingGameTitleEShop.Size = new System.Drawing.Size(243, 30);
             this.toolStripMenuItemGroupingGameTitleEShop.Text = "Game title";
             this.toolStripMenuItemGroupingGameTitleEShop.Click += new System.EventHandler(this.toolStripMenuItemGroupingGameTitleEShop_Click);
             // 
             // toolStripMenuItemGroupingDeveloperEShop
             // 
             this.toolStripMenuItemGroupingDeveloperEShop.Name = "toolStripMenuItemGroupingDeveloperEShop";
-            this.toolStripMenuItemGroupingDeveloperEShop.Size = new System.Drawing.Size(172, 22);
+            this.toolStripMenuItemGroupingDeveloperEShop.Size = new System.Drawing.Size(243, 30);
             this.toolStripMenuItemGroupingDeveloperEShop.Text = "Developer";
             this.toolStripMenuItemGroupingDeveloperEShop.Click += new System.EventHandler(this.toolStripMenuItemGroupingDeveloperEShop_Click);
             // 
             // toolStripMenuItemGroupingMasterKeyEShop
             // 
             this.toolStripMenuItemGroupingMasterKeyEShop.Name = "toolStripMenuItemGroupingMasterKeyEShop";
-            this.toolStripMenuItemGroupingMasterKeyEShop.Size = new System.Drawing.Size(172, 22);
+            this.toolStripMenuItemGroupingMasterKeyEShop.Size = new System.Drawing.Size(243, 30);
             this.toolStripMenuItemGroupingMasterKeyEShop.Text = "Masterkey revision";
             this.toolStripMenuItemGroupingMasterKeyEShop.Click += new System.EventHandler(this.toolStripMenuItemGroupingMasterKeyEShop_Click);
             // 
@@ -3588,20 +3648,20 @@
             this.toolStripMenuItem44,
             this.toolStripMenuItem65});
             this.toolStripMenuItem23.Name = "toolStripMenuItem23";
-            this.toolStripMenuItem23.Size = new System.Drawing.Size(117, 20);
+            this.toolStripMenuItem23.Size = new System.Drawing.Size(169, 29);
             this.toolStripMenuItem23.Text = "&Remove (from list)";
             // 
             // toolStripMenuItemRemoveSelectedEShop
             // 
             this.toolStripMenuItemRemoveSelectedEShop.Name = "toolStripMenuItemRemoveSelectedEShop";
-            this.toolStripMenuItemRemoveSelectedEShop.Size = new System.Drawing.Size(149, 22);
+            this.toolStripMenuItemRemoveSelectedEShop.Size = new System.Drawing.Size(209, 30);
             this.toolStripMenuItemRemoveSelectedEShop.Text = "Selected";
             this.toolStripMenuItemRemoveSelectedEShop.Click += new System.EventHandler(this.toolStripMenuItemRemoveSelectedEShop_Click);
             // 
             // toolStripSeparator8
             // 
             this.toolStripSeparator8.Name = "toolStripSeparator8";
-            this.toolStripSeparator8.Size = new System.Drawing.Size(146, 6);
+            this.toolStripSeparator8.Size = new System.Drawing.Size(206, 6);
             this.toolStripSeparator8.Visible = false;
             // 
             // toolStripMenuItem44
@@ -3610,20 +3670,20 @@
             this.toolStripMenuItemRemoveFilesOnSDCardEShop,
             this.toolStripMenuItemRemoveFilesNotOnSDCardEShop});
             this.toolStripMenuItem44.Name = "toolStripMenuItem44";
-            this.toolStripMenuItem44.Size = new System.Drawing.Size(149, 22);
+            this.toolStripMenuItem44.Size = new System.Drawing.Size(209, 30);
             this.toolStripMenuItem44.Text = "SD card";
             this.toolStripMenuItem44.Visible = false;
             // 
             // toolStripMenuItemRemoveFilesOnSDCardEShop
             // 
             this.toolStripMenuItemRemoveFilesOnSDCardEShop.Name = "toolStripMenuItemRemoveFilesOnSDCardEShop";
-            this.toolStripMenuItemRemoveFilesOnSDCardEShop.Size = new System.Drawing.Size(184, 22);
+            this.toolStripMenuItemRemoveFilesOnSDCardEShop.Size = new System.Drawing.Size(265, 30);
             this.toolStripMenuItemRemoveFilesOnSDCardEShop.Text = "Items on SD card";
             // 
             // toolStripMenuItemRemoveFilesNotOnSDCardEShop
             // 
             this.toolStripMenuItemRemoveFilesNotOnSDCardEShop.Name = "toolStripMenuItemRemoveFilesNotOnSDCardEShop";
-            this.toolStripMenuItemRemoveFilesNotOnSDCardEShop.Size = new System.Drawing.Size(184, 22);
+            this.toolStripMenuItemRemoveFilesNotOnSDCardEShop.Size = new System.Drawing.Size(265, 30);
             this.toolStripMenuItemRemoveFilesNotOnSDCardEShop.Text = "Items not on SD card";
             // 
             // toolStripMenuItem65
@@ -3632,20 +3692,20 @@
             this.toolStripMenuItem66,
             this.toolStripMenuItem67});
             this.toolStripMenuItem65.Name = "toolStripMenuItem65";
-            this.toolStripMenuItem65.Size = new System.Drawing.Size(149, 22);
+            this.toolStripMenuItem65.Size = new System.Drawing.Size(209, 30);
             this.toolStripMenuItem65.Text = "Scene releases";
             this.toolStripMenuItem65.Visible = false;
             // 
             // toolStripMenuItem66
             // 
             this.toolStripMenuItem66.Name = "toolStripMenuItem66";
-            this.toolStripMenuItem66.Size = new System.Drawing.Size(219, 22);
+            this.toolStripMenuItem66.Size = new System.Drawing.Size(316, 30);
             this.toolStripMenuItem66.Text = "Items on Scene releases";
             // 
             // toolStripMenuItem67
             // 
             this.toolStripMenuItem67.Name = "toolStripMenuItem67";
-            this.toolStripMenuItem67.Size = new System.Drawing.Size(219, 22);
+            this.toolStripMenuItem67.Size = new System.Drawing.Size(316, 30);
             this.toolStripMenuItem67.Text = "Items not on Scene releases";
             // 
             // toolStripMenuItem24
@@ -3654,7 +3714,7 @@
             this.toolStripMenuItem45,
             this.toolStripMenuItem69});
             this.toolStripMenuItem24.Name = "toolStripMenuItem24";
-            this.toolStripMenuItem24.Size = new System.Drawing.Size(75, 20);
+            this.toolStripMenuItem24.Size = new System.Drawing.Size(107, 29);
             this.toolStripMenuItem24.Text = "&Transfer to";
             // 
             // toolStripMenuItem45
@@ -3663,20 +3723,20 @@
             this.toolStripMenuItemCopyFilesToSDEShop,
             this.toolStripMenuItemMoveFilesToSDEShop});
             this.toolStripMenuItem45.Name = "toolStripMenuItem45";
-            this.toolStripMenuItem45.Size = new System.Drawing.Size(116, 22);
+            this.toolStripMenuItem45.Size = new System.Drawing.Size(158, 30);
             this.toolStripMenuItem45.Text = "SD card";
             // 
             // toolStripMenuItemCopyFilesToSDEShop
             // 
             this.toolStripMenuItemCopyFilesToSDEShop.Name = "toolStripMenuItemCopyFilesToSDEShop";
-            this.toolStripMenuItemCopyFilesToSDEShop.Size = new System.Drawing.Size(128, 22);
+            this.toolStripMenuItemCopyFilesToSDEShop.Size = new System.Drawing.Size(177, 30);
             this.toolStripMenuItemCopyFilesToSDEShop.Text = "Copy files";
             this.toolStripMenuItemCopyFilesToSDEShop.Click += new System.EventHandler(this.toolStripMenuItemCopyFilesToSDEShop_Click);
             // 
             // toolStripMenuItemMoveFilesToSDEShop
             // 
             this.toolStripMenuItemMoveFilesToSDEShop.Name = "toolStripMenuItemMoveFilesToSDEShop";
-            this.toolStripMenuItemMoveFilesToSDEShop.Size = new System.Drawing.Size(128, 22);
+            this.toolStripMenuItemMoveFilesToSDEShop.Size = new System.Drawing.Size(177, 30);
             this.toolStripMenuItemMoveFilesToSDEShop.Text = "Move files";
             this.toolStripMenuItemMoveFilesToSDEShop.Click += new System.EventHandler(this.toolStripMenuItemMoveFilesToSDEShop_Click);
             // 
@@ -3686,20 +3746,20 @@
             this.toolStripMenuItemCopyFilesToFolderEShop,
             this.toolStripMenuItemMoveFilesToFolderEShop});
             this.toolStripMenuItem69.Name = "toolStripMenuItem69";
-            this.toolStripMenuItem69.Size = new System.Drawing.Size(116, 22);
+            this.toolStripMenuItem69.Size = new System.Drawing.Size(158, 30);
             this.toolStripMenuItem69.Text = "Folder...";
             // 
             // toolStripMenuItemCopyFilesToFolderEShop
             // 
             this.toolStripMenuItemCopyFilesToFolderEShop.Name = "toolStripMenuItemCopyFilesToFolderEShop";
-            this.toolStripMenuItemCopyFilesToFolderEShop.Size = new System.Drawing.Size(128, 22);
+            this.toolStripMenuItemCopyFilesToFolderEShop.Size = new System.Drawing.Size(177, 30);
             this.toolStripMenuItemCopyFilesToFolderEShop.Text = "Copy files";
             this.toolStripMenuItemCopyFilesToFolderEShop.Click += new System.EventHandler(this.toolStripMenuItemCopyFilesToFolderEShop_Click);
             // 
             // toolStripMenuItemMoveFilesToFolderEShop
             // 
             this.toolStripMenuItemMoveFilesToFolderEShop.Name = "toolStripMenuItemMoveFilesToFolderEShop";
-            this.toolStripMenuItemMoveFilesToFolderEShop.Size = new System.Drawing.Size(128, 22);
+            this.toolStripMenuItemMoveFilesToFolderEShop.Size = new System.Drawing.Size(177, 30);
             this.toolStripMenuItemMoveFilesToFolderEShop.Text = "Move files";
             this.toolStripMenuItemMoveFilesToFolderEShop.Click += new System.EventHandler(this.toolStripMenuItemMoveFilesToFolderEShop_Click);
             // 
@@ -3707,10 +3767,11 @@
             // 
             this.tabPage5.Controls.Add(this.panel6);
             this.tabPage5.Controls.Add(this.panel7);
-            this.tabPage5.Location = new System.Drawing.Point(4, 22);
+            this.tabPage5.Location = new System.Drawing.Point(4, 29);
+            this.tabPage5.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.tabPage5.Name = "tabPage5";
-            this.tabPage5.Padding = new System.Windows.Forms.Padding(3, 3, 3, 3);
-            this.tabPage5.Size = new System.Drawing.Size(1518, 491);
+            this.tabPage5.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.tabPage5.Size = new System.Drawing.Size(2281, 752);
             this.tabPage5.TabIndex = 4;
             this.tabPage5.Text = "Log";
             this.tabPage5.UseVisualStyleBackColor = true;
@@ -3719,9 +3780,10 @@
             // 
             this.panel6.Controls.Add(this.richTextBoxLog);
             this.panel6.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panel6.Location = new System.Drawing.Point(3, 3);
+            this.panel6.Location = new System.Drawing.Point(4, 5);
+            this.panel6.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.panel6.Name = "panel6";
-            this.panel6.Size = new System.Drawing.Size(1512, 459);
+            this.panel6.Size = new System.Drawing.Size(2273, 702);
             this.panel6.TabIndex = 2;
             // 
             // richTextBoxLog
@@ -3729,9 +3791,10 @@
             this.richTextBoxLog.BackColor = System.Drawing.SystemColors.Window;
             this.richTextBoxLog.Dock = System.Windows.Forms.DockStyle.Fill;
             this.richTextBoxLog.Location = new System.Drawing.Point(0, 0);
+            this.richTextBoxLog.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.richTextBoxLog.Name = "richTextBoxLog";
             this.richTextBoxLog.ReadOnly = true;
-            this.richTextBoxLog.Size = new System.Drawing.Size(1512, 459);
+            this.richTextBoxLog.Size = new System.Drawing.Size(2273, 702);
             this.richTextBoxLog.TabIndex = 3;
             this.richTextBoxLog.Text = "";
             this.richTextBoxLog.TextChanged += new System.EventHandler(this.richTextBoxLog_TextChanged);
@@ -3740,16 +3803,18 @@
             // 
             this.panel7.Controls.Add(this.btnClearLogFile);
             this.panel7.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.panel7.Location = new System.Drawing.Point(3, 462);
+            this.panel7.Location = new System.Drawing.Point(4, 707);
+            this.panel7.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.panel7.Name = "panel7";
-            this.panel7.Size = new System.Drawing.Size(1512, 26);
+            this.panel7.Size = new System.Drawing.Size(2273, 40);
             this.panel7.TabIndex = 1;
             // 
             // btnClearLogFile
             // 
-            this.btnClearLogFile.Location = new System.Drawing.Point(1433, 2);
+            this.btnClearLogFile.Location = new System.Drawing.Point(2150, 3);
+            this.btnClearLogFile.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.btnClearLogFile.Name = "btnClearLogFile";
-            this.btnClearLogFile.Size = new System.Drawing.Size(75, 23);
+            this.btnClearLogFile.Size = new System.Drawing.Size(112, 35);
             this.btnClearLogFile.TabIndex = 0;
             this.btnClearLogFile.Text = "Clear log file";
             this.btnClearLogFile.UseVisualStyleBackColor = true;
@@ -3767,9 +3832,10 @@
             this.toolStripStatusLabel3,
             this.toolStripStatusLabel4,
             this.toolStripStatusLabel5});
-            this.statusStrip1.Location = new System.Drawing.Point(0, 418);
+            this.statusStrip1.Location = new System.Drawing.Point(0, 822);
             this.statusStrip1.Name = "statusStrip1";
-            this.statusStrip1.Size = new System.Drawing.Size(1527, 49);
+            this.statusStrip1.Padding = new System.Windows.Forms.Padding(2, 0, 21, 0);
+            this.statusStrip1.Size = new System.Drawing.Size(2291, 49);
             this.statusStrip1.TabIndex = 0;
             this.statusStrip1.Text = "statusStrip1";
             // 
@@ -3786,7 +3852,7 @@
             this.toolStripStatusLabel2.BorderSides = System.Windows.Forms.ToolStripStatusLabelBorderSides.Left;
             this.toolStripStatusLabel2.BorderStyle = System.Windows.Forms.Border3DStyle.Etched;
             this.toolStripStatusLabel2.Name = "toolStripStatusLabel2";
-            this.toolStripStatusLabel2.Size = new System.Drawing.Size(120, 44);
+            this.toolStripStatusLabel2.Size = new System.Drawing.Size(184, 44);
             this.toolStripStatusLabel2.Text = "144 Total (247,03 GB)";
             this.toolStripStatusLabel2.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
@@ -3795,7 +3861,7 @@
             this.toolStripStatusFilesOperation.BorderSides = System.Windows.Forms.ToolStripStatusLabelBorderSides.Left;
             this.toolStripStatusFilesOperation.BorderStyle = System.Windows.Forms.Border3DStyle.Etched;
             this.toolStripStatusFilesOperation.Name = "toolStripStatusFilesOperation";
-            this.toolStripStatusFilesOperation.Size = new System.Drawing.Size(83, 44);
+            this.toolStripStatusFilesOperation.Size = new System.Drawing.Size(123, 44);
             this.toolStripStatusFilesOperation.Text = "Adding files...";
             this.toolStripStatusFilesOperation.Visible = false;
             // 
@@ -3803,35 +3869,35 @@
             // 
             this.toolStripProgressAddingFiles.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
             this.toolStripProgressAddingFiles.Name = "toolStripProgressAddingFiles";
-            this.toolStripProgressAddingFiles.Size = new System.Drawing.Size(100, 43);
+            this.toolStripProgressAddingFiles.Size = new System.Drawing.Size(150, 43);
             this.toolStripProgressAddingFiles.Value = 50;
             this.toolStripProgressAddingFiles.Visible = false;
             // 
             // toolStripStatusLabelGame
             // 
             this.toolStripStatusLabelGame.Name = "toolStripStatusLabelGame";
-            this.toolStripStatusLabelGame.Size = new System.Drawing.Size(58, 44);
+            this.toolStripStatusLabelGame.Size = new System.Drawing.Size(89, 44);
             this.toolStripStatusLabelGame.Text = "game aaa";
             this.toolStripStatusLabelGame.Visible = false;
             // 
             // toolStripStatusLabel3
             // 
             this.toolStripStatusLabel3.Name = "toolStripStatusLabel3";
-            this.toolStripStatusLabel3.Size = new System.Drawing.Size(86, 44);
+            this.toolStripStatusLabel3.Size = new System.Drawing.Size(131, 44);
             this.toolStripStatusLabel3.Text = "Files on XCI list";
             this.toolStripStatusLabel3.Visible = false;
             // 
             // toolStripStatusLabel4
             // 
             this.toolStripStatusLabel4.Name = "toolStripStatusLabel4";
-            this.toolStripStatusLabel4.Size = new System.Drawing.Size(105, 44);
+            this.toolStripStatusLabel4.Size = new System.Drawing.Size(160, 44);
             this.toolStripStatusLabel4.Text = "Files on E-shop list";
             this.toolStripStatusLabel4.Visible = false;
             // 
             // toolStripStatusLabel5
             // 
             this.toolStripStatusLabel5.Name = "toolStripStatusLabel5";
-            this.toolStripStatusLabel5.Size = new System.Drawing.Size(180, 44);
+            this.toolStripStatusLabel5.Size = new System.Drawing.Size(271, 44);
             this.toolStripStatusLabel5.Text = "Files on Both lists (XCI && E-shop)";
             this.toolStripStatusLabel5.Visible = false;
             // 
@@ -3844,7 +3910,8 @@
             this.viewToolStripMenuItem});
             this.menuStrip1.Location = new System.Drawing.Point(0, 0);
             this.menuStrip1.Name = "menuStrip1";
-            this.menuStrip1.Size = new System.Drawing.Size(1527, 24);
+            this.menuStrip1.Padding = new System.Windows.Forms.Padding(9, 3, 0, 3);
+            this.menuStrip1.Size = new System.Drawing.Size(2291, 35);
             this.menuStrip1.TabIndex = 2;
             this.menuStrip1.Text = "menuStrip1";
             // 
@@ -3855,25 +3922,25 @@
             this.toolStripMenuItem19,
             this.exitToolStripMenuItem});
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(50, 29);
             this.fileToolStripMenuItem.Text = "&File";
             // 
             // optionsToolStripMenuItem
             // 
             this.optionsToolStripMenuItem.Name = "optionsToolStripMenuItem";
-            this.optionsToolStripMenuItem.Size = new System.Drawing.Size(125, 22);
+            this.optionsToolStripMenuItem.Size = new System.Drawing.Size(172, 30);
             this.optionsToolStripMenuItem.Text = "&Options...";
             this.optionsToolStripMenuItem.Click += new System.EventHandler(this.optionsToolStripMenuItem_Click);
             // 
             // toolStripMenuItem19
             // 
             this.toolStripMenuItem19.Name = "toolStripMenuItem19";
-            this.toolStripMenuItem19.Size = new System.Drawing.Size(122, 6);
+            this.toolStripMenuItem19.Size = new System.Drawing.Size(169, 6);
             // 
             // exitToolStripMenuItem
             // 
             this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
-            this.exitToolStripMenuItem.Size = new System.Drawing.Size(125, 22);
+            this.exitToolStripMenuItem.Size = new System.Drawing.Size(172, 30);
             this.exitToolStripMenuItem.Text = "&Exit";
             this.exitToolStripMenuItem.Click += new System.EventHandler(this.exitToolStripMenuItem_Click);
             // 
@@ -3886,20 +3953,20 @@
             this.updateVersionListToolStripMenuItem,
             this.scrapExtendedInfoFromWebToolStripMenuItem});
             this.toolsToolStripMenuItem1.Name = "toolsToolStripMenuItem1";
-            this.toolsToolStripMenuItem1.Size = new System.Drawing.Size(47, 20);
+            this.toolsToolStripMenuItem1.Size = new System.Drawing.Size(65, 29);
             this.toolsToolStripMenuItem1.Text = "&Tools";
             // 
             // updateLocalDatabaseToolStripMenuItem
             // 
             this.updateLocalDatabaseToolStripMenuItem.Name = "updateLocalDatabaseToolStripMenuItem";
-            this.updateLocalDatabaseToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
+            this.updateLocalDatabaseToolStripMenuItem.Size = new System.Drawing.Size(336, 30);
             this.updateLocalDatabaseToolStripMenuItem.Text = "&Update local database";
             this.updateLocalDatabaseToolStripMenuItem.Click += new System.EventHandler(this.updateLocalDatabaseToolStripMenuItem_Click);
             // 
             // updateEshopLocalDatabaseToolStripMenuItem
             // 
             this.updateEshopLocalDatabaseToolStripMenuItem.Name = "updateEshopLocalDatabaseToolStripMenuItem";
-            this.updateEshopLocalDatabaseToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
+            this.updateEshopLocalDatabaseToolStripMenuItem.Size = new System.Drawing.Size(336, 30);
             this.updateEshopLocalDatabaseToolStripMenuItem.Text = "Update e-shop local database";
             this.updateEshopLocalDatabaseToolStripMenuItem.Visible = false;
             this.updateEshopLocalDatabaseToolStripMenuItem.Click += new System.EventHandler(this.updateEshopLocalDatabaseToolStripMenuItem_Click);
@@ -3907,21 +3974,21 @@
             // updateNswdbcomListToolStripMenuItem1
             // 
             this.updateNswdbcomListToolStripMenuItem1.Name = "updateNswdbcomListToolStripMenuItem1";
-            this.updateNswdbcomListToolStripMenuItem1.Size = new System.Drawing.Size(232, 22);
+            this.updateNswdbcomListToolStripMenuItem1.Size = new System.Drawing.Size(336, 30);
             this.updateNswdbcomListToolStripMenuItem1.Text = "Update nswdb.com list";
             this.updateNswdbcomListToolStripMenuItem1.Click += new System.EventHandler(this.updateNswdbcomListToolStripMenuItem1_Click);
             // 
             // updateVersionListToolStripMenuItem
             // 
             this.updateVersionListToolStripMenuItem.Name = "updateVersionListToolStripMenuItem";
-            this.updateVersionListToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
+            this.updateVersionListToolStripMenuItem.Size = new System.Drawing.Size(336, 30);
             this.updateVersionListToolStripMenuItem.Text = "Update version list";
             this.updateVersionListToolStripMenuItem.Click += new System.EventHandler(this.updateVersionListToolStripMenuItem_Click);
             // 
             // scrapExtendedInfoFromWebToolStripMenuItem
             // 
             this.scrapExtendedInfoFromWebToolStripMenuItem.Name = "scrapExtendedInfoFromWebToolStripMenuItem";
-            this.scrapExtendedInfoFromWebToolStripMenuItem.Size = new System.Drawing.Size(232, 22);
+            this.scrapExtendedInfoFromWebToolStripMenuItem.Size = new System.Drawing.Size(336, 30);
             this.scrapExtendedInfoFromWebToolStripMenuItem.Text = "Scrap extended info from web";
             this.scrapExtendedInfoFromWebToolStripMenuItem.Click += new System.EventHandler(this.scrapExtendedInfoFromWebToolStripMenuItem_Click);
             // 
@@ -3931,20 +3998,20 @@
             this.bottonPanelToolStripMenuItem,
             this.leftPanelToolStripMenuItem});
             this.viewToolStripMenuItem.Name = "viewToolStripMenuItem";
-            this.viewToolStripMenuItem.Size = new System.Drawing.Size(44, 20);
+            this.viewToolStripMenuItem.Size = new System.Drawing.Size(61, 29);
             this.viewToolStripMenuItem.Text = "&View";
             // 
             // bottonPanelToolStripMenuItem
             // 
             this.bottonPanelToolStripMenuItem.Name = "bottonPanelToolStripMenuItem";
-            this.bottonPanelToolStripMenuItem.Size = new System.Drawing.Size(146, 22);
+            this.bottonPanelToolStripMenuItem.Size = new System.Drawing.Size(204, 30);
             this.bottonPanelToolStripMenuItem.Text = "&Bottom panel";
             this.bottonPanelToolStripMenuItem.Click += new System.EventHandler(this.bottonPanelToolStripMenuItem_Click);
             // 
             // leftPanelToolStripMenuItem
             // 
             this.leftPanelToolStripMenuItem.Name = "leftPanelToolStripMenuItem";
-            this.leftPanelToolStripMenuItem.Size = new System.Drawing.Size(146, 22);
+            this.leftPanelToolStripMenuItem.Size = new System.Drawing.Size(204, 30);
             this.leftPanelToolStripMenuItem.Text = "&Left panel";
             this.leftPanelToolStripMenuItem.Click += new System.EventHandler(this.leftPanelToolStripMenuItem_Click);
             // 
@@ -3963,152 +4030,179 @@
             this.panelEditTitle.Controls.Add(this.panel14);
             this.panelEditTitle.Dock = System.Windows.Forms.DockStyle.Fill;
             this.panelEditTitle.Location = new System.Drawing.Point(0, 0);
+            this.panelEditTitle.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.panelEditTitle.Name = "panelEditTitle";
-            this.panelEditTitle.Size = new System.Drawing.Size(1527, 218);
+            this.panelEditTitle.Size = new System.Drawing.Size(2291, 378);
             this.panelEditTitle.TabIndex = 0;
             // 
             // groupBox10
             // 
             this.groupBox10.Controls.Add(this.textBoxReleaseDate);
-            this.groupBox10.Location = new System.Drawing.Point(227, 121);
+            this.groupBox10.Location = new System.Drawing.Point(340, 186);
+            this.groupBox10.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.groupBox10.Name = "groupBox10";
-            this.groupBox10.Size = new System.Drawing.Size(121, 50);
+            this.groupBox10.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.groupBox10.Size = new System.Drawing.Size(182, 77);
             this.groupBox10.TabIndex = 7;
             this.groupBox10.TabStop = false;
             this.groupBox10.Text = "Release Date";
             // 
             // textBoxReleaseDate
             // 
-            this.textBoxReleaseDate.Location = new System.Drawing.Point(7, 20);
+            this.textBoxReleaseDate.Location = new System.Drawing.Point(10, 31);
+            this.textBoxReleaseDate.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.textBoxReleaseDate.Name = "textBoxReleaseDate";
-            this.textBoxReleaseDate.Size = new System.Drawing.Size(108, 20);
+            this.textBoxReleaseDate.Size = new System.Drawing.Size(160, 26);
             this.textBoxReleaseDate.TabIndex = 0;
             // 
             // groupBox9
             // 
             this.groupBox9.Controls.Add(this.textBoxCategory);
-            this.groupBox9.Location = new System.Drawing.Point(683, 123);
+            this.groupBox9.Location = new System.Drawing.Point(1024, 189);
+            this.groupBox9.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.groupBox9.Name = "groupBox9";
-            this.groupBox9.Size = new System.Drawing.Size(346, 50);
+            this.groupBox9.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.groupBox9.Size = new System.Drawing.Size(519, 77);
             this.groupBox9.TabIndex = 10;
             this.groupBox9.TabStop = false;
             this.groupBox9.Text = "Category";
             // 
             // textBoxCategory
             // 
-            this.textBoxCategory.Location = new System.Drawing.Point(7, 20);
+            this.textBoxCategory.Location = new System.Drawing.Point(10, 31);
+            this.textBoxCategory.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.textBoxCategory.Name = "textBoxCategory";
-            this.textBoxCategory.Size = new System.Drawing.Size(333, 20);
+            this.textBoxCategory.Size = new System.Drawing.Size(498, 26);
             this.textBoxCategory.TabIndex = 0;
             // 
             // groupBox8
             // 
             this.groupBox8.Controls.Add(this.textBoxPublisher);
-            this.groupBox8.Location = new System.Drawing.Point(683, 66);
+            this.groupBox8.Location = new System.Drawing.Point(1024, 102);
+            this.groupBox8.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.groupBox8.Name = "groupBox8";
-            this.groupBox8.Size = new System.Drawing.Size(452, 50);
+            this.groupBox8.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.groupBox8.Size = new System.Drawing.Size(678, 77);
             this.groupBox8.TabIndex = 9;
             this.groupBox8.TabStop = false;
             this.groupBox8.Text = "Publisher";
             // 
             // textBoxPublisher
             // 
-            this.textBoxPublisher.Location = new System.Drawing.Point(7, 20);
+            this.textBoxPublisher.Location = new System.Drawing.Point(10, 31);
+            this.textBoxPublisher.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.textBoxPublisher.Name = "textBoxPublisher";
-            this.textBoxPublisher.Size = new System.Drawing.Size(437, 20);
+            this.textBoxPublisher.Size = new System.Drawing.Size(654, 26);
             this.textBoxPublisher.TabIndex = 0;
             // 
             // groupBox7
             // 
             this.groupBox7.Controls.Add(this.textBoxDeveloper);
-            this.groupBox7.Location = new System.Drawing.Point(683, 9);
+            this.groupBox7.Location = new System.Drawing.Point(1024, 14);
+            this.groupBox7.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.groupBox7.Name = "groupBox7";
-            this.groupBox7.Size = new System.Drawing.Size(452, 50);
+            this.groupBox7.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.groupBox7.Size = new System.Drawing.Size(678, 77);
             this.groupBox7.TabIndex = 8;
             this.groupBox7.TabStop = false;
             this.groupBox7.Text = "Developer";
             // 
             // textBoxDeveloper
             // 
-            this.textBoxDeveloper.Location = new System.Drawing.Point(7, 20);
+            this.textBoxDeveloper.Location = new System.Drawing.Point(10, 31);
+            this.textBoxDeveloper.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.textBoxDeveloper.Name = "textBoxDeveloper";
-            this.textBoxDeveloper.Size = new System.Drawing.Size(437, 20);
+            this.textBoxDeveloper.Size = new System.Drawing.Size(654, 26);
             this.textBoxDeveloper.TabIndex = 0;
             // 
             // groupBox6
             // 
             this.groupBox6.Controls.Add(this.textBoxPlayers);
-            this.groupBox6.Location = new System.Drawing.Point(1035, 123);
+            this.groupBox6.Location = new System.Drawing.Point(1552, 189);
+            this.groupBox6.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.groupBox6.Name = "groupBox6";
-            this.groupBox6.Size = new System.Drawing.Size(100, 50);
+            this.groupBox6.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.groupBox6.Size = new System.Drawing.Size(150, 77);
             this.groupBox6.TabIndex = 7;
             this.groupBox6.TabStop = false;
             this.groupBox6.Text = "Players";
             // 
             // textBoxPlayers
             // 
-            this.textBoxPlayers.Location = new System.Drawing.Point(7, 20);
+            this.textBoxPlayers.Location = new System.Drawing.Point(10, 31);
+            this.textBoxPlayers.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.textBoxPlayers.Name = "textBoxPlayers";
-            this.textBoxPlayers.Size = new System.Drawing.Size(85, 20);
+            this.textBoxPlayers.Size = new System.Drawing.Size(126, 26);
             this.textBoxPlayers.TabIndex = 0;
             // 
             // groupBox5
             // 
             this.groupBox5.Controls.Add(this.textBoxFirmware);
-            this.groupBox5.Location = new System.Drawing.Point(100, 121);
+            this.groupBox5.Location = new System.Drawing.Point(150, 186);
+            this.groupBox5.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.groupBox5.Name = "groupBox5";
-            this.groupBox5.Size = new System.Drawing.Size(121, 50);
+            this.groupBox5.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.groupBox5.Size = new System.Drawing.Size(182, 77);
             this.groupBox5.TabIndex = 6;
             this.groupBox5.TabStop = false;
             this.groupBox5.Text = "Firmware";
             // 
             // textBoxFirmware
             // 
-            this.textBoxFirmware.Location = new System.Drawing.Point(7, 20);
+            this.textBoxFirmware.Location = new System.Drawing.Point(10, 31);
+            this.textBoxFirmware.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.textBoxFirmware.Name = "textBoxFirmware";
-            this.textBoxFirmware.Size = new System.Drawing.Size(108, 20);
+            this.textBoxFirmware.Size = new System.Drawing.Size(160, 26);
             this.textBoxFirmware.TabIndex = 0;
             // 
             // groupBox4
             // 
             this.groupBox4.Controls.Add(this.textBoxCardType);
-            this.groupBox4.Location = new System.Drawing.Point(7, 121);
+            this.groupBox4.Location = new System.Drawing.Point(10, 186);
+            this.groupBox4.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.groupBox4.Name = "groupBox4";
-            this.groupBox4.Size = new System.Drawing.Size(87, 50);
+            this.groupBox4.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.groupBox4.Size = new System.Drawing.Size(130, 77);
             this.groupBox4.TabIndex = 5;
             this.groupBox4.TabStop = false;
             this.groupBox4.Text = "Card type";
             // 
             // textBoxCardType
             // 
-            this.textBoxCardType.Location = new System.Drawing.Point(7, 20);
+            this.textBoxCardType.Location = new System.Drawing.Point(10, 31);
+            this.textBoxCardType.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.textBoxCardType.Name = "textBoxCardType";
-            this.textBoxCardType.Size = new System.Drawing.Size(74, 20);
+            this.textBoxCardType.Size = new System.Drawing.Size(109, 26);
             this.textBoxCardType.TabIndex = 0;
             // 
             // groupBox3
             // 
             this.groupBox3.Controls.Add(this.textBoxLanguages);
-            this.groupBox3.Location = new System.Drawing.Point(7, 65);
+            this.groupBox3.Location = new System.Drawing.Point(10, 100);
+            this.groupBox3.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.groupBox3.Name = "groupBox3";
-            this.groupBox3.Size = new System.Drawing.Size(341, 50);
+            this.groupBox3.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.groupBox3.Size = new System.Drawing.Size(512, 77);
             this.groupBox3.TabIndex = 4;
             this.groupBox3.TabStop = false;
             this.groupBox3.Text = "Languages";
             // 
             // textBoxLanguages
             // 
-            this.textBoxLanguages.Location = new System.Drawing.Point(7, 20);
+            this.textBoxLanguages.Location = new System.Drawing.Point(10, 31);
+            this.textBoxLanguages.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.textBoxLanguages.Name = "textBoxLanguages";
-            this.textBoxLanguages.Size = new System.Drawing.Size(328, 20);
+            this.textBoxLanguages.Size = new System.Drawing.Size(490, 26);
             this.textBoxLanguages.TabIndex = 0;
             // 
             // groupBox2
             // 
             this.groupBox2.Controls.Add(this.richTextBoxDescription);
-            this.groupBox2.Location = new System.Drawing.Point(354, 9);
+            this.groupBox2.Location = new System.Drawing.Point(531, 14);
+            this.groupBox2.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(323, 162);
+            this.groupBox2.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.groupBox2.Size = new System.Drawing.Size(484, 249);
             this.groupBox2.TabIndex = 3;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Description";
@@ -4116,36 +4210,41 @@
             // richTextBoxDescription
             // 
             this.richTextBoxDescription.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.richTextBoxDescription.Location = new System.Drawing.Point(3, 16);
+            this.richTextBoxDescription.Location = new System.Drawing.Point(4, 24);
+            this.richTextBoxDescription.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.richTextBoxDescription.Name = "richTextBoxDescription";
-            this.richTextBoxDescription.Size = new System.Drawing.Size(317, 143);
+            this.richTextBoxDescription.Size = new System.Drawing.Size(476, 220);
             this.richTextBoxDescription.TabIndex = 0;
             this.richTextBoxDescription.Text = "";
             // 
             // groupBox1
             // 
             this.groupBox1.Controls.Add(this.textBoxGameTitle);
-            this.groupBox1.Location = new System.Drawing.Point(7, 9);
+            this.groupBox1.Location = new System.Drawing.Point(10, 14);
+            this.groupBox1.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(341, 50);
+            this.groupBox1.Padding = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.groupBox1.Size = new System.Drawing.Size(512, 77);
             this.groupBox1.TabIndex = 2;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Game title";
             // 
             // textBoxGameTitle
             // 
-            this.textBoxGameTitle.Location = new System.Drawing.Point(7, 20);
+            this.textBoxGameTitle.Location = new System.Drawing.Point(10, 31);
+            this.textBoxGameTitle.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.textBoxGameTitle.Name = "textBoxGameTitle";
-            this.textBoxGameTitle.Size = new System.Drawing.Size(328, 20);
+            this.textBoxGameTitle.Size = new System.Drawing.Size(490, 26);
             this.textBoxGameTitle.TabIndex = 0;
             // 
             // panel14
             // 
             this.panel14.Controls.Add(this.panel15);
             this.panel14.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.panel14.Location = new System.Drawing.Point(0, 184);
+            this.panel14.Location = new System.Drawing.Point(0, 326);
+            this.panel14.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.panel14.Name = "panel14";
-            this.panel14.Size = new System.Drawing.Size(1527, 34);
+            this.panel14.Size = new System.Drawing.Size(2291, 52);
             this.panel14.TabIndex = 1;
             // 
             // panel15
@@ -4153,15 +4252,17 @@
             this.panel15.Controls.Add(this.button1);
             this.panel15.Dock = System.Windows.Forms.DockStyle.Left;
             this.panel15.Location = new System.Drawing.Point(0, 0);
+            this.panel15.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.panel15.Name = "panel15";
-            this.panel15.Size = new System.Drawing.Size(86, 34);
+            this.panel15.Size = new System.Drawing.Size(129, 52);
             this.panel15.TabIndex = 0;
             // 
             // button1
             // 
-            this.button1.Location = new System.Drawing.Point(6, 6);
+            this.button1.Location = new System.Drawing.Point(9, 9);
+            this.button1.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(75, 23);
+            this.button1.Size = new System.Drawing.Size(112, 35);
             this.button1.TabIndex = 1;
             this.button1.Text = "Save";
             this.button1.UseVisualStyleBackColor = true;
@@ -4205,14 +4306,20 @@
             this.backgroundWorkerScrapExtraInfo.DoWork += new System.ComponentModel.DoWorkEventHandler(this.backgroundWorkerScrapExtraInfo_DoWork);
             this.backgroundWorkerScrapExtraInfo.RunWorkerCompleted += new System.ComponentModel.RunWorkerCompletedEventHandler(this.backgroundWorkerScrapExtraInfo_RunWorkerCompleted);
             // 
+            // backgroundWorkerUpdateVersionList
+            // 
+            this.backgroundWorkerUpdateVersionList.DoWork += new System.ComponentModel.DoWorkEventHandler(this.backgroundWorkerUpdateVersionList_DoWork);
+            this.backgroundWorkerUpdateVersionList.RunWorkerCompleted += new System.ComponentModel.RunWorkerCompletedEventHandler(this.backgroundWorkerUpdateVersionList_RunWorkerCompleted);
+            // 
             // FrmMain
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1880, 690);
+            this.ClientSize = new System.Drawing.Size(2820, 1255);
             this.Controls.Add(this.splitContainer1);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MainMenuStrip = this.menuStrip1;
+            this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.Name = "FrmMain";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Switch Backup Manager";
@@ -4739,6 +4846,7 @@
         private BrightIdeasSoftware.OLVColumn olvColumnLatestSD;
         private BrightIdeasSoftware.OLVColumn olvColumnSourceSD;
         private System.Windows.Forms.ToolStripMenuItem updateVersionListToolStripMenuItem;
+        private System.ComponentModel.BackgroundWorker backgroundWorkerUpdateVersionList;
     }
 }
 

--- a/Switch Backup Manager/Form1.cs
+++ b/Switch Backup Manager/Form1.cs
@@ -4212,6 +4212,12 @@ namespace Switch_Backup_Manager
 
         private void backgroundWorkerUpdateVersionList_DoWork(object sender, DoWorkEventArgs e)
         {
+            if (TitleVersionList.Count == 0)
+            {
+                Util.UpdateVersionList();
+                TitleVersionList = Util.LoadVersionListToDictionary();
+            }
+
             foreach (FileData data in LocalFilesList.Values)
             {
                 int latest = -1;
@@ -4219,7 +4225,7 @@ namespace Switch_Backup_Manager
                 if (latest != -1)
                 {
                     data.Latest = latest.ToString();
-                    Util.UpdateXMLFromFileData(data, "local");
+                    //Util.UpdateXMLFromFileData(data, "local");
                 }
             }
 
@@ -4232,7 +4238,7 @@ namespace Switch_Backup_Manager
                     if (latest != -1)
                     {
                         data.Latest = latest.ToString();
-                        Util.UpdateXMLFromFileData(data, "eshop");
+                        //Util.UpdateXMLFromFileData(data, "eshop");
                     }
                 }
             }
@@ -4253,8 +4259,8 @@ namespace Switch_Backup_Manager
 
         private void backgroundWorkerUpdateVersionList_RunWorkerCompleted(object sender, RunWorkerCompletedEventArgs e)
         {
-            Util.XML_Local.Save(@Util.LOCAL_FILES_DB);
-            Util.XML_NSP_Local.Save(@Util.LOCAL_NSP_FILES_DB);
+            //Util.XML_Local.Save(@Util.LOCAL_FILES_DB);
+            //Util.XML_NSP_Local.Save(@Util.LOCAL_NSP_FILES_DB);
         }
     }
 }

--- a/Switch Backup Manager/Form1.cs
+++ b/Switch Backup Manager/Form1.cs
@@ -120,6 +120,7 @@ namespace Switch_Backup_Manager
 
             SetupOLVs();
 
+            UpdateTitleVersionList();
             UpdateSceneReleasesList();
             UpdateLocalGamesList();
             UpdateLocalNSPGamesList();
@@ -3739,7 +3740,6 @@ namespace Switch_Backup_Manager
 
             UpdateLocalGamesList();
             UpdateLocalNSPGamesList();
-            UpdateTitleVersionList();
             tabControl1_SelectedIndexChanged(this, new EventArgs());
         }
 
@@ -4197,10 +4197,6 @@ namespace Switch_Backup_Manager
         public void UpdateTitleVersionList()
         {
             TitleVersionList = Util.LoadVersionListToDictionary();
-            if (!backgroundWorkerUpdateVersionList.IsBusy)
-            {
-                backgroundWorkerUpdateVersionList.RunWorkerAsync();
-            }
         }
 
         private void updateVersionListToolStripMenuItem_Click(object sender, EventArgs e)
@@ -4208,16 +4204,15 @@ namespace Switch_Backup_Manager
             Util.UpdateVersionList();
             UpdateTitleVersionList();
             MessageBox.Show("Done.");
+
+            if (!backgroundWorkerUpdateVersionList.IsBusy)
+            {
+                backgroundWorkerUpdateVersionList.RunWorkerAsync();
+            }
         }
 
         private void backgroundWorkerUpdateVersionList_DoWork(object sender, DoWorkEventArgs e)
         {
-            if (TitleVersionList.Count == 0)
-            {
-                Util.UpdateVersionList();
-                TitleVersionList = Util.LoadVersionListToDictionary();
-            }
-
             foreach (FileData data in LocalFilesList.Values)
             {
                 int latest = -1;

--- a/Switch Backup Manager/Util.cs
+++ b/Switch Backup Manager/Util.cs
@@ -1183,7 +1183,7 @@ namespace Switch_Backup_Manager
                                    new XElement("ID_Scene", data.IdScene),
                                    new XElement("Content_Type", data.ContentType),
                                    new XElement("Version", data.Version),
-                                   new XElement("Latest", data.Latest),
+                                   //new XElement("Latest", data.Latest),
                                    new XElement("HasExtendedInfo", data.HasExtendedInfo),
                                    new XElement("Description", data.Description),
                                    new XElement("Publisher", data.Publisher),
@@ -1613,7 +1613,7 @@ namespace Switch_Backup_Manager
         {
             using (var client = new WebClient())
             {
-                if (File.Exists(CLIENT_CERT_FILE))
+                if (false /*File.Exists(CLIENT_CERT_FILE)*/) //Temporary disabled for now
                 {
                     string header = "";
 
@@ -3360,10 +3360,6 @@ namespace Switch_Backup_Manager
                 {
                     result.Version = xe.Element("Version").Value;
                 }
-                if (xe.Element("Latest") != null)
-                {
-                    result.Latest = xe.Element("Latest").Value;
-                }
                 if (xe.Element("CartSize") != null)
                 {
                     result.CartSize = xe.Element("CartSize").Value;
@@ -3522,6 +3518,10 @@ namespace Switch_Backup_Manager
                 if (xe.Element("ESRB") != null)
                 {
                     result.ESRB = Convert.ToInt32(xe.Element("ESRB").Value);
+                }
+                if (xe.Element("Latest") != null)
+                {
+                    result.Latest = (result.ContentType != "AddOnContent" ? "0" : ""); //xe.Element("Latest").Value;
                 }
                 if (xe.Element("Source") != null)
                 {

--- a/Switch Backup Manager/Util.cs
+++ b/Switch Backup Manager/Util.cs
@@ -1183,7 +1183,7 @@ namespace Switch_Backup_Manager
                                    new XElement("ID_Scene", data.IdScene),
                                    new XElement("Content_Type", data.ContentType),
                                    new XElement("Version", data.Version),
-                                   //new XElement("Latest", data.Latest),
+                                   new XElement("Latest", data.Latest),
                                    new XElement("HasExtendedInfo", data.HasExtendedInfo),
                                    new XElement("Description", data.Description),
                                    new XElement("Publisher", data.Publisher),
@@ -3360,6 +3360,10 @@ namespace Switch_Backup_Manager
                 {
                     result.Version = xe.Element("Version").Value;
                 }
+                //if (xe.Element("Latest") != null)
+                //{
+                //    result.Latest = xe.Element("Latest").Value;
+                //}
                 if (xe.Element("CartSize") != null)
                 {
                     result.CartSize = xe.Element("CartSize").Value;
@@ -3519,13 +3523,23 @@ namespace Switch_Backup_Manager
                 {
                     result.ESRB = Convert.ToInt32(xe.Element("ESRB").Value);
                 }
-                if (xe.Element("Latest") != null)
-                {
-                    result.Latest = (result.ContentType != "AddOnContent" ? "0" : ""); //xe.Element("Latest").Value;
-                }
                 if (xe.Element("Source") != null)
                 {
                     result.Source = xe.Element("Source").Value;
+                }
+
+                if (result.ContentType != "AddOnContent")
+                {
+                    int latest = -1;
+                    FrmMain.TitleVersionList.TryGetValue(result.TitleID.Substring(0, 13).ToUpper() + "000", out latest);
+                    if (latest != -1)
+                    {
+                        result.Latest = latest.ToString();
+                    }
+                    else
+                    {
+                        result.Latest = "0";
+                    }
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
so the Form1.Designer.cs file was messed up. if you only want to fix the compilation issue, you can just apply that

but I've also added another implementation in this PR

latest version information is no longer stored in the XML (this was slow previously as it needs to save to XML for each entry in the DB), and moved to map the latest version info when loading data from the XML instead
this should be faster and better than before where the latest version data was refreshed one at a time
but if the user initiate "Update version list" from the menu, this will still happen but not as noticeable as before

but there's also bad news. my method for getting version list directly from nintendo server no longer works now (damn I did that only to find it no longer works 2 days later), so I disabled it and default to download from the pastebin instead