### PR TITLE
Handle exception if there's duplicate TitleID in titlekeys.txt

### DIFF
--- a/Switch Backup Manager/Consts.cs
+++ b/Switch Backup Manager/Consts.cs
@@ -6,10 +6,6 @@ namespace Switch_Backup_Manager
     {
         public static Dictionary<string, string> UPDATE_FILES = new Dictionary<string, string>
         {
-            //hactool.exe -t xci --updatedir=update file.xci
-            //hactool.exe -t nca --listromfs update\file.cnmt.nca
-            //hactool.exe -t nca --section0dir=updates update\file.cnmt.nca
-            //updates\SystemUpdate_0100000000000816.cnmt
             //https://gist.github.com/garoxas/b6f2db2542250b2b34aeecc3f6fe273e
             { "1.0.0", "73af776d8a1abb72507aa0c51a53adec.cnmt.nca" },
             { "2.0.0", "2d4c96214d911cd1a2ed7a1875827a86.cnmt.nca" },
@@ -27,6 +23,7 @@ namespace Switch_Backup_Manager
             { "5.x.x", "e9f9f9bb6087e68e6dd9ce0e56eb70df.cnmt.nca" }, //5.0.2
             { "6.0.0", "9965b2a2ea6b66723c4a7c25cdd888c9.cnmt.nca" },
             { "6.0.1", "7a242c9c6feb5686c8d0a19fec5c8ab9.cnmt.nca" },
+            { "6.1.0", "a28317f1b2e0a35149dea5f7a85685ef.cnmt.nca" },
         };
 
         public static Dictionary<string, int> UPDATE_NUMBER_OF_FILES = new Dictionary<string, int>
@@ -49,6 +46,7 @@ namespace Switch_Backup_Manager
             { "5.x.x", 207 }, //5.0.2
             { "6.0.0", 211 },
             { "6.0.1", 211 },
+            { "6.1.0", 211 },
         };
 
         public enum NSPSource

--- a/Switch Backup Manager/Form1.cs
+++ b/Switch Backup Manager/Form1.cs
@@ -4220,7 +4220,6 @@ namespace Switch_Backup_Manager
                 if (latest != -1)
                 {
                     data.Latest = latest.ToString();
-                    //Util.UpdateXMLFromFileData(data, "local");
                 }
             }
 
@@ -4233,7 +4232,6 @@ namespace Switch_Backup_Manager
                     if (latest != -1)
                     {
                         data.Latest = latest.ToString();
-                        //Util.UpdateXMLFromFileData(data, "eshop");
                     }
                 }
             }
@@ -4254,8 +4252,6 @@ namespace Switch_Backup_Manager
 
         private void backgroundWorkerUpdateVersionList_RunWorkerCompleted(object sender, RunWorkerCompletedEventArgs e)
         {
-            //Util.XML_Local.Save(@Util.LOCAL_FILES_DB);
-            //Util.XML_NSP_Local.Save(@Util.LOCAL_NSP_FILES_DB);
         }
     }
 }

--- a/Switch Backup Manager/Util.cs
+++ b/Switch Backup Manager/Util.cs
@@ -2399,7 +2399,7 @@ namespace Switch_Backup_Manager
                                     gameName = (from x in File.ReadAllLines(TITLE_KEYS)
                                                 select x.Split('|') into x
                                                 where x.Length > 1
-                                                select x).ToDictionary((string[] x) => x[0].Trim().Substring(0, 16), (string[] x) => x[2])[data.TitleID.ToLower()];
+                                                select x).GroupBy(x => x[0].Trim().Substring(0, 16)).ToDictionary(x => x.Key, x => x.ToList()[0][2])[data.TitleID.ToLower()];
                                     data.GameName = gameName.Replace("[DLC] ", "");
                                     found = true;
                                 }
@@ -2415,7 +2415,7 @@ namespace Switch_Backup_Manager
                                         gameName = (from x in File.ReadAllLines(TITLE_KEYS)
                                                     select x.Split('|') into x
                                                     where x.Length > 1
-                                                    select x).ToDictionary((string[] x) => x[0].Trim().Substring(0, 16), (string[] x) => x[2])[data.TitleIDBaseGame.ToLower()];
+                                                    select x).GroupBy(x => x[0].Trim().Substring(0, 16)).ToDictionary(x => x.Key, x => x.ToList()[0][2])[data.TitleIDBaseGame.ToLower()];
                                     }
                                     catch (Exception e)
                                     {
@@ -2635,7 +2635,7 @@ namespace Switch_Backup_Manager
                                                 gameName = (from x in File.ReadAllLines(TITLE_KEYS)
                                                             select x.Split('|') into x
                                                             where x.Length > 1
-                                                            select x).ToDictionary((string[] x) => x[0].Trim().Substring(0, 16), (string[] x) => x[2])[data.TitleID.ToLower()];
+                                                            select x).GroupBy(x => x[0].Trim().Substring(0, 16)).ToDictionary(x => x.Key, x => x.ToList()[0][2])[data.TitleID.ToLower()];
                                                 data.GameName = gameName.Replace("[DLC] ", "");
                                                 found = true;
                                             }
@@ -2651,7 +2651,7 @@ namespace Switch_Backup_Manager
                                                     gameName = (from x in File.ReadAllLines(TITLE_KEYS)
                                                                 select x.Split('|') into x
                                                                 where x.Length > 1
-                                                                select x).ToDictionary((string[] x) => x[0].Trim().Substring(0, 16), (string[] x) => x[2])[data.TitleIDBaseGame.ToLower()];
+                                                                select x).GroupBy(x => x[0].Trim().Substring(0, 16)).ToDictionary(x => x.Key, x => x.ToList()[0][2])[data.TitleIDBaseGame.ToLower()];
                                                 }
                                                 catch (Exception e)
                                                 {

--- a/Switch Backup Manager/Util.cs
+++ b/Switch Backup Manager/Util.cs
@@ -1736,7 +1736,7 @@ namespace Switch_Backup_Manager
                 case 5:
                     return "MasterKey4 (5.0.0-5.1.0)";
                 case 6:
-                    return "MasterKey5 (6.0.0-6.0.1)";
+                    return "MasterKey5 (6.0.0-6.1.0)";
                 case 7:
                     return "MasterKey6 (?)";
                 case 8:
@@ -2206,7 +2206,7 @@ namespace Switch_Backup_Manager
                         data.ContentType = xml.Element("ContentMeta").Element("Type").Value;
                         data.Version = xml.Element("ContentMeta").Element("Version").Value;
 
-                        //0100000000000816,ALL,v65796 v131162 v196628 v262164 v201327002 v201392178 v201457684 v268435656 v268501002 v269484082 v335544750 v335609886 v335675432 v336592976 v402653544 v402718730,2.0.0 2.1.0 2.2.0 2.3.0 3.0.0 3.0.1 3.0.2 4.0.0 4.0.1 4.1.0 5.0.0 5.0.1 5.0.2 5.1.0 6.0.0 6.0.1
+                        //0100000000000816,ALL,v65796 v131162 v196628 v262164 v201327002 v201392178 v201457684 v268435656 v268501002 v269484082 v335544750 v335609886 v335675432 v336592976 v402653544 v402718730 v403701850,2.0.0 2.1.0 2.2.0 2.3.0 3.0.0 3.0.1 3.0.2 4.0.0 4.0.1 4.1.0 5.0.0 5.0.1 5.0.2 5.1.0 6.0.0 6.0.1 6.1.0
                         data.Firmware = "";
                         long Firmware = Convert.ToInt64(xml.Element("ContentMeta").Element("RequiredSystemVersion").Value) % 0x100000000;
                         if (Firmware == 0)
@@ -2280,6 +2280,10 @@ namespace Switch_Backup_Manager
                         else if (Firmware <= 402718730)
                         {
                             data.Firmware = "6.0.1";
+                        }
+                        else if (Firmware <= 403701850)
+                        {
+                            data.Firmware = "6.1.0";
                         }
                         else
                         {


### PR DESCRIPTION
This commit handles exception if there's duplicate TitleID in titlekeys.txt causing error "An item with the same key has already been added." when converting to dictionary

Here's sample of duplicate TitleID (titlekeys.txt generated from the latest nutdb)
```
010023f0082040000000000000000005|00000000000000000000000000000000|百鬼城 公儀隠密録
010023f0082040000000000000000005|00000000000000000000000000000000|Haunted Dungeons : Hyakki Castle

010076c009f030010000000000000004|00000000000000000000000000000000|GOD WARS 日本神話大戦 []
010076c009f030010000000000000004|00000000000000000000000000000000|GOD WARS 日本神話大戦 [GOD WARS 日本神話大戦 追加アイテム『密林の槍セット』]
```