### PR TITLE
Fix NSP release by BBB with unescaped XML entity in .nacp.xml

### DIFF
--- a/Switch Backup Manager/Form1.cs
+++ b/Switch Backup Manager/Form1.cs
@@ -1767,7 +1767,7 @@ namespace Switch_Backup_Manager
             else if (e.ColumnIndex == this.olvColumnSourceLocal.Index)
             {
                 FileData data = (FileData)e.Model;
-                if ((data.Source.Contains("NSP") && data.Source != "CDNSP") || data.Source.Contains("NCA"))
+                if (data.Source.Contains("NSP") || data.Source.Contains("NCA"))
                     e.SubItem.BackColor = Color.IndianRed;
             }
         }
@@ -2869,7 +2869,7 @@ namespace Switch_Backup_Manager
             else if (e.ColumnIndex == this.olvColumnSourceSD.Index)
             {
                 FileData data = (FileData)e.Model;
-                if (data.Source.Contains("XCI") || (data.Source.Contains("NSP") && data.Source != "CDNSP") || data.Source.Contains("NCA"))
+                if (data.Source.Contains("XCI") || data.Source.Contains("NSP") || data.Source.Contains("NCA"))
                     e.SubItem.BackColor = Color.IndianRed;
             }
         }

--- a/Switch Backup Manager/Util.cs
+++ b/Switch Backup Manager/Util.cs
@@ -2454,13 +2454,13 @@ namespace Switch_Backup_Manager
                         fileStream.Read(array4, 0, (int)array3[n].Size);
 
                         byte[] byteOrderMarkUtf8 = Encoding.UTF8.GetPreamble();
-                        XDocument xml = XDocument.Parse(Encoding.UTF8.GetString(array4.Take(byteOrderMarkUtf8.Length).SequenceEqual(byteOrderMarkUtf8) ? array4.Skip(byteOrderMarkUtf8.Length).ToArray() : array4));
                         try
                         {
+                            XDocument xml = XDocument.Parse(Encoding.UTF8.GetString(array4.Take(byteOrderMarkUtf8.Length).SequenceEqual(byteOrderMarkUtf8) ? array4.Skip(byteOrderMarkUtf8.Length).ToArray() : array4).Replace("&", "&amp;"));
                             data.GameName = xml.Element("Application").Element("Title").Element("Name").Value;
+                            data.GameRevision = xml.Element("Application").Element("DisplayVersion").Value;
                         }
                         catch { }
-                        data.GameRevision = xml.Element("Application").Element("DisplayVersion").Value;
                     }
                     else if (array3[n].Name.EndsWith(".programinfo.xml"))
                     {
@@ -2639,7 +2639,7 @@ namespace Switch_Backup_Manager
                                                 gameName = (from x in File.ReadAllLines(TITLE_KEYS)
                                                             select x.Split('|') into x
                                                             where x.Length > 1
-                                                            select x).GroupBy(x => x[0].Trim().Substring(0, 16)).ToDictionary(x => x.Key, x => x.ToList()[0][2])[data.TitleID.ToLower()];
+                                                            select x).GroupBy(x => x[0].Trim().Substring(0, 16)).ToDictionary(x => x.Key, x => x.ToList()[0][2], StringComparer.OrdinalIgnoreCase)[data.TitleID];
                                                 data.GameName = gameName.Replace("[DLC] ", "");
                                                 found = true;
                                             }
@@ -2655,7 +2655,7 @@ namespace Switch_Backup_Manager
                                                     gameName = (from x in File.ReadAllLines(TITLE_KEYS)
                                                                 select x.Split('|') into x
                                                                 where x.Length > 1
-                                                                select x).GroupBy(x => x[0].Trim().Substring(0, 16)).ToDictionary(x => x.Key, x => x.ToList()[0][2])[data.TitleIDBaseGame.ToLower()];
+                                                                select x).GroupBy(x => x[0].Trim().Substring(0, 16)).ToDictionary(x => x.Key, x => x.ToList()[0][2], StringComparer.OrdinalIgnoreCase)[data.TitleIDBaseGame];
                                                 }
                                                 catch (Exception e)
                                                 {
@@ -2725,7 +2725,7 @@ namespace Switch_Backup_Manager
                 }
                 else if (nspSource == (1 << 3) - 1)
                 {
-                    data.Source = "CDNSP";
+                    data.Source = "CDN";
                 }
                 else if (nspSource == (1 << 1) - 1)
                 {


### PR DESCRIPTION
Hey,

Here's another update from me

- Fix NSP release by BBB with unescaped XML entity in .nacp.xml
As reported in GBAtemp that some NSPs cannot be added to the list, apparently the issue was because of the extra file on BBB release not properly XML escaped
for example it has an XML with the following data **&lt;Publisher&gt;Image & Form&lt;/Publisher&gt;**, instead of **&lt;Publisher&gt;Image &amp;amp; Form&lt;/Publisher&gt;**, and that cannot be handled by XDocument.Parse method
Lastly, since retrieving extra data from .nacp.xml is actually optional, I've enclosed the entire XML parsing within a try-catch so any further errors do not prevent NSP to be added to the list

- Case insensitive TitleKeys lookup
I've recently found titlekeys.txt file using uppercase instead of the usual lowercase, so I added some logic to handle both cases during titlekeys lookup

- Change Source from "CDNSP" to "CDN"
This is just cosmetic. Previously I'm using **CDNSP** for NSPs that having similar set of files with NSP downloaded using CDNSP. But since there are other methods other than CDNSP to download directly from Nintendo CDN, so I renamed it as simply **CDN**