### PR TITLE
Show error log for banned certificates

### DIFF
--- a/Switch Backup Manager/Util.cs
+++ b/Switch Backup Manager/Util.cs
@@ -1716,8 +1716,15 @@ namespace Switch_Backup_Manager
             {
                 HttpWebRequest request = (HttpWebRequest) base.GetWebRequest(address);
 
-                X509Certificate2 certificate = new X509Certificate2(CLIENT_CERT_FILE, "switch");
-                request.ClientCertificates.Add(certificate);
+                try
+                {
+                    X509Certificate2 certificate = new X509Certificate2(CLIENT_CERT_FILE, "switch");
+                    request.ClientCertificates.Add(certificate);
+                }
+                catch (CryptographicException)
+                {
+                    logger.Error("Certificate is not a valid PFX certificate.");
+                }
 
                 request.KeepAlive = true;
 
@@ -1731,7 +1738,7 @@ namespace Switch_Backup_Manager
             {
                 if (File.Exists(CLIENT_CERT_FILE))
                 {
-                    logger.Info("Certificate " + CLIENT_CERT_FILE + " found. Starting download version list from nintendo");
+                    logger.Info("Certificate " + CLIENT_CERT_FILE + " found. Starting download version list from Nintendo");
 
                     string header = "";
 
@@ -1779,18 +1786,38 @@ namespace Switch_Backup_Manager
                             }
                             catch (Exception ex)
                             {
-                                logger.Error("Could not download version list. " + ex.StackTrace);
-                                MessageBox.Show("Could not download version list! \n Please check your internet connection.");
+                                bool banned = false;
+
+                                if (ex is WebException)
+                                {
+                                    if (((WebException)ex).Status == WebExceptionStatus.ProtocolError)
+                                    {
+                                        HttpWebResponse response = ((WebException)ex).Response as HttpWebResponse;
+                                        if (response != null)
+                                        {
+                                            if (response.StatusCode == HttpStatusCode.Forbidden)
+                                            {
+                                                logger.Error("Could not download version list. Certificate is banned or not a valid PFX certificate.");
+                                                banned = true;
+                                            }
+                                        }
+                                    }
+                                }
+
+                                if (!banned)
+                                {
+                                    logger.Error("Could not download version list. " + ex.StackTrace);
+                                }
                             }
                         }
                     }
 
-                    logger.Error("Could not download version list from nintendo. Starting download cached version list from pastebin");
+                    logger.Error("Failed to download version list from Nintendo. Starting download cached version list from Pastebin");
                 }
 
                 if (!File.Exists(CLIENT_CERT_FILE))
                 {
-                    logger.Info("No certificates " + CLIENT_CERT_FILE + " found. Starting download cached version list from pastebin");
+                    logger.Info("No certificates " + CLIENT_CERT_FILE + " found. Starting download cached version list from Pastebin");
                 }
 
                 try
@@ -1819,10 +1846,9 @@ namespace Switch_Backup_Manager
                 catch (Exception ex)
                 {
                     logger.Error("Could not download cached version list. " + ex.StackTrace);
-                    MessageBox.Show("Could not download cached version list! \n Please check your internet connection.");
                 }
 
-                logger.Error("Could not download cached version list from pastebin. Please check your internet connection.");
+                logger.Error("Failed to download cached version list from Pastebin. Please check your internet connection.");
             }
         }
 


### PR DESCRIPTION
- Show info in error log for banned certificates and certificates that is not in valid PFX format
- Fix crash when using invalid PFX certificate
- Some wording
- Close #105 