### PR TITLE
Auto renaming and Master Key log

### DIFF
--- a/Switch Backup Manager/FormConfigs.cs
+++ b/Switch Backup Manager/FormConfigs.cs
@@ -35,10 +35,10 @@ namespace Switch_Backup_Manager
             gameExample.ContentType = "Patch";
             gameExample.Version = "0";
 
-            gameExampleNSP = new FileData("C:\\Switch\\1-2-Switch [01000320000cc000][v0].nsp", "1-2-Switch [01000320000cc000][v0]", "1-2-Switch [01000320000cc000][v0].nsp", 
-                "1,38 GB", 1481339176, "1,38 GB", 1481339176, "01000320000CC000" , "01000320000CC000", "1-2-Switch", "Nintendo", "1.0.0", "No Prod. ID", "0.12.12.0", "e-shop", 
-                "0 (1.0.0-2.3.0)", new Dictionary<string, string> { { "American English", "cache\\icon_01000320000CC000_AmericanEnglish.bmp" }, { "Japanese", "cache\\icon_01000320000CC000_Japanese.bmp" } },
-                new List<string> { "American English", "Japanese" }, "en, ja", true, "", "", "0", "e-shop", "", false, "Download", 0, "Application", "0", "0", true, "", "Nintendo", "Mar 03, 2017", 
+            gameExampleNSP = new FileData("C:\\Switch\\1-2-Switch [01000320000CC800][v65536].nsp", "1-2-Switch [01000320000CC800][v65536]", "1-2-Switch [01000320000CC800][v65536].nsp",
+                "12,18 MB", 12770575, "12,18 MB", 12770575, "01000320000CC800", "01000320000CC000", "1-2-Switch", "Nintendo", "1.1.0", "No Prod. ID", "4.4.0.0", "e-shop",
+                "3 (4.0.0-4.1.0)", new Dictionary<string, string> { { "American English", "cache\\icon_01000320000CC000_AmericanEnglish.bmp" }, { "Japanese", "cache\\icon_01000320000CC000_Japanese.bmp" } },
+                new List<string> { "American English", "Japanese" }, "en, ja", true, "BigBlueBox", "LA-H-AACCA", "4.0.0", "e-shop", "WLD", false, "Download", 12, "Patch", "65536", "65536", true, "", "Nintendo", "Mar 03, 2017", 
                 "2 players simultaneous", new List<string> { "Party", "Multiplayer", "Action" }, 0, "");
 
             cbxTagsXCI.Items.Clear();

--- a/Switch Backup Manager/FormConfigs.cs
+++ b/Switch Backup Manager/FormConfigs.cs
@@ -24,7 +24,9 @@ namespace Switch_Backup_Manager
             gameExample.Developer = "Nintendo";
             gameExample.GameRevision = "1.0.0";
             gameExample.IsTrimmed = true;
-            gameExample.FilePath = @"c:\switch\mario.xci";
+            gameExample.FilePath = @"C:\Switch\bbb-h-aaaca.xci";
+            gameExample.FileName = "bbb-h-aaaca";
+            gameExample.FileNameWithExt = "bbb-h-aaaca.xci";
             gameExample.Group = "BigBlueBox";
             gameExample.Region = "WLD";
             gameExample.Firmware = "3.0.1";
@@ -32,7 +34,7 @@ namespace Switch_Backup_Manager
                 "Latin American Spanish", "Spanish", "Italian", "Dutch", "Canadian French", "Russian" };
             gameExample.Languages_resumed = "en,fr,de,it,es,nl,ru,ja";
             gameExample.IdScene = 38;
-            gameExample.ContentType = "Patch";
+            gameExample.ContentType = "Application";
             gameExample.Version = "0";
 
             gameExampleNSP = new FileData("C:\\Switch\\1-2-Switch [01000320000CC800][v65536].nsp", "1-2-Switch [01000320000CC800][v65536]", "1-2-Switch [01000320000CC800][v65536].nsp",
@@ -45,7 +47,7 @@ namespace Switch_Backup_Manager
             cbxTagsNSP.Items.Clear();
             for (int i = 0; i < Util.AutoRenamingTags.Length; i++)
             {
-                if (Util.AutoRenamingTags[i] != "{nspversion}" && Util.AutoRenamingTags[i] != "{content_type}")
+                if (Util.AutoRenamingTags[i] != "{nspversion}" && Util.AutoRenamingTags[i] != "{content_type}" && Util.AutoRenamingTags[i] != "{nsptype}")
                     cbxTagsXCI.Items.Add(Util.AutoRenamingTags[i]);
                 cbxTagsNSP.Items.Add(Util.AutoRenamingTags[i]);
             }

--- a/Switch Backup Manager/Util.cs
+++ b/Switch Backup Manager/Util.cs
@@ -69,7 +69,7 @@ namespace Switch_Backup_Manager
         public static Color HighlightNSPOnScene_color = Color.Orange;
         public static Color HighlightBothOnScene_color = Color.Yellow;
 
-        private static string[] Language = new string[16]
+        private static string[] Language = new string[]
         {
             "American English",
             "British English",
@@ -89,7 +89,7 @@ namespace Switch_Backup_Manager
             "???"
         };
 
-        public static string[] AutoRenamingTags = new string[12]
+        public static string[] AutoRenamingTags = new string[]
         {
             "{gamename}",
             "{titleid}",
@@ -102,7 +102,9 @@ namespace Switch_Backup_Manager
             "{languages}",
             "{sceneid}",
             "{nspversion}",
-            "{content_type}"
+            "{content_type}",
+            "{nsptype}",
+            "{filename}",
         };
 
         private static Image[] Icons = new Image[16];
@@ -641,15 +643,18 @@ namespace Switch_Backup_Manager
                 else
                 {
                     string content_type = ""; //Patch, AddOnContent, Application
+                    string nsptype = ""; //Patch, AddOnContent, Application
                     if (data.ContentType != "")
                     {
                         switch (data.ContentType)
                         {
                             case "Patch":
                                 content_type = "Update";
+                                nsptype = "UPD";
                                 break;
                             case "AddOnContent":
                                 content_type = "DLC";
+                                nsptype = "DLC";
                                 break;
                             case "Application":
                                 content_type = "Base Game";
@@ -669,6 +674,45 @@ namespace Switch_Backup_Manager
                     result = result.Replace(AutoRenamingTags[9], string.Format("{0:D4}", data.IdScene));
                     result = result.Replace(AutoRenamingTags[10], data.Version);
                     result = result.Replace(AutoRenamingTags[11], content_type);
+                    result = result.Replace(AutoRenamingTags[12], nsptype);
+
+                    if (result.Contains(AutoRenamingTags[13]))
+                    {
+                        string filename = "";
+                        Regex regex = new Regex(@"^(?:(?:\[[\w ]+\] ?)?(.*?) (?:\[[\w ]+\] ?)?\[[a-zA-Z0-9]{16}\] ?\[v?\d+\]|([\w\-]+?)(?:_(?:dlc|[a-zA-Z0-9]{16}|v?\d+))+)");
+                        MatchCollection matches = regex.Matches(data.FileName);
+                        if (matches.Count != 0)
+                        {
+                            GroupCollection group = matches[0].Groups;
+                            if (group.Count == 3)
+                            {
+                                if (!string.IsNullOrEmpty(group[1].ToString()))
+                                {
+                                    filename = group[1].ToString();
+                                }
+                                else if (!string.IsNullOrEmpty(group[2].ToString()))
+                                {
+                                    filename = group[2].ToString();
+                                }
+                                else
+                                {
+                                    filename = group[0].ToString();
+                                }
+                            }
+                            else
+                            {
+                                filename = matches[0].ToString();
+                            }
+                        }
+                        else
+                        {
+                            filename = data.FileName;
+                        }
+
+                        result = result.Replace(AutoRenamingTags[13], filename);
+                    }
+
+                    result = result.Replace("[]", "").Replace("  ", " ").Trim();
                 }
                 if (MaxSizeFilenameNSP != 0)
                 {


### PR DESCRIPTION
This PR has the following changes

- Add _{nsptype}_ and _{filename}_ to Auto renaming
**{nsptype}** is pretty self-explanatory, it basically an alternative of **{content_type}** where instead of instead of **Base Game**, **Update** and **DLC** it's now **(empty)**, **UPD** and **DLC**  
**{filename}** on the other hand is quite complicated. it'll try to guess what the original file name is

for example, the following files will be renamed as below
    - Ace of Seafood [0100FF1004D56000][v0] => Ace of Seafood
    - Yet Another Zombie Defense HD [Base game][010085500B29A800][v65536] => Yet Another Zombie Defense HD
    - v-disgaea1c_v196608 => v-disgaea1c
    - v-dragon_ball_fighterz_dlc_0100a250097f100a => v-dragon_ball_fighterz

make a backup before trying to rename all your games collection

- Show error message on Debug Log when **keys.txt** having duplicate values which prevent the app from running
- Show error message on Debug Log if games require master key not found in **keys.txt**
for example
**Section 0 directory missing! Please check if you have required key in keys.txt. Master Key 7**
- Fix some NSP base games not read properly, e.g. Grand Prix Story