### PR TITLE
Fix cart update partition above 6.2.0

### DIFF
--- a/Switch Backup Manager/Consts.cs
+++ b/Switch Backup Manager/Consts.cs
@@ -25,6 +25,11 @@ namespace Switch_Backup_Manager
             { "6.0.1", "7a242c9c6feb5686c8d0a19fec5c8ab9.cnmt.nca" },
             { "6.1.0", "a28317f1b2e0a35149dea5f7a85685ef.cnmt.nca" },
             { "6.2.0", "b95330de60c858d6e470c652e33ca79a.cnmt.nca" },
+            { "7.0.0", "9ed86369ab18298ac5610f8d23937404.cnmt.nca" },
+            { "7.0.1", "404e81473afa604f5e710efa4c3456c6.cnmt.nca" },
+            { "8.0.0", "91b479d7df0bf1208299ce886af4d924.cnmt.nca" },
+            { "8.0.1", "083cc22d83fd121484fb6f5903434b00.cnmt.nca" },
+            { "8.1.0", "23930617edcd63e6415ac12d88b3ff69.cnmt.nca" },
         };
 
         public static Dictionary<string, int> UPDATE_NUMBER_OF_FILES = new Dictionary<string, int>
@@ -49,6 +54,11 @@ namespace Switch_Backup_Manager
             { "6.0.1", 211 },
             { "6.1.0", 211 },
             { "6.2.0", 211 },
+            { "7.0.0", 211 },
+            { "7.0.1", 211 },
+            { "8.0.0", 213 },
+            { "8.0.1", 213 },
+            { "8.1.0", 213 },
         };
 
         public enum NSPSource

--- a/Switch Backup Manager/Util.cs
+++ b/Switch Backup Manager/Util.cs
@@ -3296,19 +3296,6 @@ namespace Switch_Backup_Manager
                                 break;
                             }
                         }
-
-                        //Last resort, guess by Number of files in Update Partition
-                        if (String.IsNullOrEmpty(result.Firmware))
-                        {
-                            foreach (KeyValuePair<string, int> kv in Consts.UPDATE_NUMBER_OF_FILES)
-                            {
-                                if (UpdateFiles.Count == kv.Value)
-                                {
-                                    result.Firmware = kv.Key;
-                                    break;
-                                }
-                            }
-                        }
                     }
                 }
                 long num3 = -9223372036854775808L;


### PR DESCRIPTION
Cart with update partition on firmware above 6.2.0 was detected as 6.2.0, this issue has been resolved in this PR
Along with adding update partition firmware detection up to 8.1.0
Games that have been previously added to the list will keep detected as 6.2.0 though, unless user remove and add them again