### PR TITLE
Remove download version update directly from N server

### DIFF
--- a/Switch Backup Manager/Util.cs
+++ b/Switch Backup Manager/Util.cs
@@ -1795,7 +1795,7 @@ namespace Switch_Backup_Manager
         {
             using (var client = new WebClient())
             {
-                if (File.Exists(CLIENT_CERT_FILE))
+                if (File.Exists(CLIENT_CERT_FILE) && MessageBox.Show("Updating directly from Nintendo may no longer work and may get your certificate banned. Do you still wish to continue?", "", MessageBoxButtons.YesNo) == DialogResult.Yes)
                 {
                     logger.Info("Certificate " + CLIENT_CERT_FILE + " found. Started to download version list from Nintendo");
 


### PR DESCRIPTION
Seeing that update version list from N server may no longer work now, as haven't seen any report that it's still working while on the other hand multiple reports that it's no longer working (such as in #144 and Reswitched discord), I added a warning if user still wants to try to connect directly to N server

This is to minimize the risk of users unknowingly use clean certificate on this app and getting the certificate banned while doing so (no reports that certificate is definitely banned either ATM, just no longer works in the app)