### PR TITLE
Partial NSZ support

### DIFF
--- a/Switch Backup Manager/CNMT.cs
+++ b/Switch Backup Manager/CNMT.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace Switch_Backup_Manager
@@ -17,6 +18,17 @@ namespace Switch_Backup_Manager
             public short ContentCount;
             public short MetaCount;
             public byte[] Reserved2;
+
+            [StructLayout(LayoutKind.Explicit)]
+            public struct Extended
+            {
+                [FieldOffset(0)] public long PatchID;
+                [FieldOffset(0)] public long ApplicationID;
+                [FieldOffset(4)] public int RequiredSystemVersion;
+                [FieldOffset(4)] public int RequiredApplicationVersion;
+            }
+
+            public Extended ExtendedData;
 
             public enum TitleType
             {
@@ -40,8 +52,10 @@ namespace Switch_Backup_Manager
                 Reserved1 = Data[13];
                 Offset = BitConverter.ToInt16(data, 14);
                 ContentCount = BitConverter.ToInt16(data, 16);
-                MetaCount = BitConverter.ToInt16(data, 16);
+                MetaCount = BitConverter.ToInt16(data, 18);
                 Reserved2 = Data.Skip(20).Take(12).ToArray();
+                ExtendedData.PatchID = BitConverter.ToInt64(data, 32);
+                ExtendedData.RequiredSystemVersion = BitConverter.ToInt32(data, 40);
             }
         }
 

--- a/Switch Backup Manager/Consts.cs
+++ b/Switch Backup Manager/Consts.cs
@@ -30,6 +30,8 @@ namespace Switch_Backup_Manager
             { "8.0.0", "91b479d7df0bf1208299ce886af4d924.cnmt.nca" },
             { "8.0.1", "083cc22d83fd121484fb6f5903434b00.cnmt.nca" },
             { "8.1.0", "23930617edcd63e6415ac12d88b3ff69.cnmt.nca" },
+            { "9.0.0", "639f559130a79648aa313ae5cbecce3c.cnmt.nca" },
+            { "9.0.1", "48f6fd812daffc80970314eee2072eb6.cnmt.nca" },
         };
 
         public static Dictionary<string, int> UPDATE_NUMBER_OF_FILES = new Dictionary<string, int>
@@ -59,6 +61,8 @@ namespace Switch_Backup_Manager
             { "8.0.0", 213 },
             { "8.0.1", 213 },
             { "8.1.0", 213 },
+            { "9.0.0", 216 },
+            { "9.0.1", 216 },
         };
 
         public enum NSPSource

--- a/Switch Backup Manager/Form1.cs
+++ b/Switch Backup Manager/Form1.cs
@@ -1806,7 +1806,7 @@ namespace Switch_Backup_Manager
         private void filesToolStripMenuItem_Click(object sender, EventArgs e)
         {            
             OpenFileDialog openFileDialog = new OpenFileDialog();
-            openFileDialog.Filter = "XCI Files (*.XCI;*.XC0)|*.xci;*.xc0";
+            openFileDialog.Filter = "XCI Files (*.XCI;*.XC0;*.XCZ)|*.xci;*.xc0;*.xcz";
             openFileDialog.Multiselect = true;
             openFileDialog.Title = "Switch Backup Manager - Add Files";
             openFileDialog.RestoreDirectory = true;

--- a/Switch Backup Manager/Form1.cs
+++ b/Switch Backup Manager/Form1.cs
@@ -3296,7 +3296,7 @@ namespace Switch_Backup_Manager
         private void filesToolStripMenuItem1_Click(object sender, EventArgs e)
         {
             OpenFileDialog openFileDialog = new OpenFileDialog();
-            openFileDialog.Filter = "NSP Files (*.NSP)|*.nsp";
+            openFileDialog.Filter = "NSP Files (*.NSP;*.NSZ)|*.nsp;*.nsz";
             openFileDialog.Multiselect = true;
             openFileDialog.Title = "Switch Backup Manager - Add Files";
             openFileDialog.RestoreDirectory = true;

--- a/Switch Backup Manager/Util.cs
+++ b/Switch Backup Manager/Util.cs
@@ -1757,7 +1757,12 @@ namespace Switch_Backup_Manager
 
                     foreach (var title in titles.titles)
                     {
-                        result.Add(Convert.ToString(title.id).Substring(0, 13).ToUpper() + "000", Convert.ToInt32(title.version));
+                        string id = Convert.ToString(title.id).Substring(0, 13).ToUpper() + "000";
+                        result.TryGetValue(id, out int version);
+                        if (title.version > version)
+                        {
+                            result[id] = title.version;
+                        }
                     }
 
                     FrmMain.TitleVersionUpdate = Convert.ToInt32(titles.last_modified);

--- a/Switch Backup Manager/Util.cs
+++ b/Switch Backup Manager/Util.cs
@@ -1845,7 +1845,7 @@ namespace Switch_Backup_Manager
                 case 9:
                     return "MasterKey8 (8.1.0)";
                 case 10:
-                    return "MasterKey9 (?)";
+                    return "MasterKey9 (9.0.0-9.0.1)";
                 case 11:
                     return "MasterKey10 (?)";
                 case 12:
@@ -2334,62 +2334,6 @@ namespace Switch_Backup_Manager
                         {
                             data.Firmware = "2.3.0";
                         }
-                        else if (Firmware <= 201327002)
-                        {
-                            data.Firmware = "3.0.0";
-                        }
-                        else if (Firmware <= 201392178)
-                        {
-                            data.Firmware = "3.0.1";
-                        }
-                        else if (Firmware <= 201457684)
-                        {
-                            data.Firmware = "3.0.2";
-                        }
-                        else if (Firmware <= 268435656)
-                        {
-                            data.Firmware = "4.0.0";
-                        }
-                        else if (Firmware <= 268501002)
-                        {
-                            data.Firmware = "4.0.1";
-                        }
-                        else if (Firmware <= 269484082)
-                        {
-                            data.Firmware = "4.1.0";
-                        }
-                        else if (Firmware <= 335544750)
-                        {
-                            data.Firmware = "5.0.0";
-                        }
-                        else if (Firmware <= 335609886)
-                        {
-                            data.Firmware = "5.0.1";
-                        }
-                        else if (Firmware <= 335675432)
-                        {
-                            data.Firmware = "5.0.2";
-                        }
-                        else if (Firmware <= 336592976)
-                        {
-                            data.Firmware = "5.1.0";
-                        }
-                        else if (Firmware <= 402653544)
-                        {
-                            data.Firmware = "6.0.0";
-                        }
-                        else if (Firmware <= 402718730)
-                        {
-                            data.Firmware = "6.0.1";
-                        }
-                        else if (Firmware <= 403701850)
-                        {
-                            data.Firmware = "6.1.0";
-                        }
-                        else if (Firmware <= 404750376)
-                        {
-                            data.Firmware = "6.2.0";
-                        }
                         else
                         {
                             data.Firmware = ((Firmware >> 26) & 0x3F) + "." + ((Firmware >> 20) & 0x3F) + "." + ((Firmware >> 16) & 0x0F);
@@ -2660,11 +2604,11 @@ namespace Switch_Backup_Manager
                                 {
                                     using (FileStream fileStream3 = File.OpenRead(cnmt[0]))
                                     {
-                                        byte[] buffer = new byte[32];
+                                        byte[] buffer = new byte[44];
                                         byte[] buffer2 = new byte[56];
                                         CNMT.CNMT_Header[] array7 = new CNMT.CNMT_Header[1];
 
-                                        fileStream3.Read(buffer, 0, 32);
+                                        fileStream3.Read(buffer, 0, 44);
                                         array7[0] = new CNMT.CNMT_Header(buffer);
 
                                         byte[] TitleID = BitConverter.GetBytes(array7[0].TitleID);
@@ -2683,6 +2627,39 @@ namespace Switch_Backup_Manager
                                         else if (array7[0].Type == (byte)CNMT.CNMT_Header.TitleType.ADD_ON_CONTENT)
                                         {
                                             data.ContentType = "AddOnContent";
+                                        }
+
+                                        if (data.ContentType != "AddOnContent")
+                                        {
+                                            long Firmware = array7[0].ExtendedData.RequiredSystemVersion;
+                                            if (Firmware == 0)
+                                            {
+                                                data.Firmware = "0";
+                                            }
+                                            else if (Firmware <= 450)
+                                            {
+                                                data.Firmware = "1.0.0";
+                                            }
+                                            else if (Firmware <= 65796)
+                                            {
+                                                data.Firmware = "2.0.0";
+                                            }
+                                            else if (Firmware <= 131162)
+                                            {
+                                                data.Firmware = "2.1.0";
+                                            }
+                                            else if (Firmware <= 196628)
+                                            {
+                                                data.Firmware = "2.2.0";
+                                            }
+                                            else if (Firmware <= 262164)
+                                            {
+                                                data.Firmware = "2.3.0";
+                                            }
+                                            else
+                                            {
+                                                data.Firmware = ((Firmware >> 26) & 0x3F) + "." + ((Firmware >> 20) & 0x3F) + "." + ((Firmware >> 16) & 0x0F);
+                                            }
                                         }
 
                                         string titleIDBaseGame = data.TitleID;

--- a/Switch Backup Manager/Util.cs
+++ b/Switch Backup Manager/Util.cs
@@ -933,6 +933,7 @@ namespace Switch_Backup_Manager
                 switch (extension.ToLower())
                 {
                     case ".xci":
+                    case ".xcz":
                         logger.Info("Old name: " + file.FileNameWithExt + ". New name: " + illegalInFileName.Replace(GetRenamingString(file, autoRenamingPattern), ""));
                         try
                         {
@@ -2227,6 +2228,11 @@ namespace Switch_Backup_Manager
 
         public static FileData GetFileDataNSP(string file)
         {
+            if (Path.GetExtension(file).ToLower() == ".nsz")
+            {
+                logger.Warning("NSZ format is only partially supported");
+            }
+
             FileData data = new FileData();
             data.ImportedDate = DateTime.Now.ToString("yyyy/MM/dd HH:mm:ss");
             data.FilePath = file;
@@ -3025,6 +3031,11 @@ namespace Switch_Backup_Manager
 
         public static FileData GetFileData(string filepath)
         {
+            if (Path.GetExtension(filepath).ToLower() == ".xcz")
+            {
+                logger.Warning("XCZ format is only partially supported");
+            }
+
             FileData result = new FileData();
             result.ImportedDate = DateTime.Now.ToString("yyyy/MM/dd HH:mm:ss");
             //Basic Info
@@ -3872,7 +3883,7 @@ namespace Switch_Backup_Manager
             {
                 FrmMain.progressCurrentfile = file;
                 FileData data;
-                if (Path.GetExtension(file) == ".xci")
+                if (Array.Exists(new string[] { ".xci", ".xcz" }, x => x == Path.GetExtension(file).ToLower()))
                 {
                     data = GetFileData(file);
                 }
@@ -3885,7 +3896,7 @@ namespace Switch_Backup_Manager
                 {
                     if (!String.IsNullOrEmpty(data.TitleID))
                     {
-                        result.Add(new Tuple<string, string>(data.TitleID, Path.GetExtension(file) == ".xci" ? data.Firmware : data.Version), data);
+                        result.Add(new Tuple<string, string>(data.TitleID, Array.Exists(new string[] { ".xci", ".xcz" }, x => x == Path.GetExtension(file).ToLower()) ? data.Firmware : data.Version), data);
                     }
                 }
                 catch
@@ -3906,12 +3917,7 @@ namespace Switch_Backup_Manager
 
             try
             {
-                foreach (string f in Directory.GetFiles(folder, "*.xci", System.IO.SearchOption.AllDirectories))
-                {
-                    list.Add(f);
-                }
-
-                foreach (string f in Directory.GetFiles(folder, "*.xc0", System.IO.SearchOption.AllDirectories))
+                foreach (string f in Directory.GetFiles(folder, "*.xc*", System.IO.SearchOption.AllDirectories).Where(x => x.ToLower().EndsWith(".xci") || x.ToLower().EndsWith(".xc0") || x.ToLower().EndsWith(".xcz")))
                 {
                     list.Add(f);
                 }

--- a/Switch Backup Manager/Util.cs
+++ b/Switch Backup Manager/Util.cs
@@ -916,7 +916,7 @@ namespace Switch_Backup_Manager
             {
                 string renamingPattern = "";
                 string extension = Path.GetExtension(file.FilePath);
-                renamingPattern = extension.ToLower() == ".nsp" ? autoRenamingPatternNSP : autoRenamingPattern;
+                renamingPattern = extension.ToLower() == ".nsp" || extension.ToLower() == ".nsz" ? autoRenamingPatternNSP : autoRenamingPattern;
 
                 Regex illegalInFileName = new Regex(@"[\\/:*?""<>|™®]");
                 string newFileName = Path.GetDirectoryName(file.FilePath) + "\\" + illegalInFileName.Replace(GetRenamingString(file, renamingPattern), "");
@@ -946,6 +946,7 @@ namespace Switch_Backup_Manager
                         }
                         break;
                     case ".nsp":
+                    case ".nsz":
                         logger.Info("Old name: " + file.FileNameWithExt + ". New name: " + illegalInFileName.Replace(GetRenamingString(file, autoRenamingPatternNSP), ""));
                         try
                         {
@@ -3947,7 +3948,7 @@ namespace Switch_Backup_Manager
 
             try
             {
-                foreach (string f in Directory.GetFiles(folder, "*.nsp", System.IO.SearchOption.AllDirectories))
+                foreach (string f in Directory.GetFiles(folder, "*.ns*", System.IO.SearchOption.AllDirectories).Where(x => x.ToLower().EndsWith(".nsp") || x.ToLower().EndsWith(".nsz")))
                 {
                     list.Add(f);
                 }


### PR DESCRIPTION
why **Partial**? because this PR simply make use the fact that NSZ is identical to NSP with only difference that program NCA is now compressed and renamed as NCZ (see https://github.com/nicoboss/nsz)
this PR assume that NSZ file will keep the other NCA intact and proceed as usual, however if in the future some of the other NCA are also compressed, then as expected it will no longer working

along with this I've also added few QoL changes
- XCZ *partial* support (same thing with NSZ, not tested since it's not widely used)
- Allow read RequiredSystemVersion from cnmt.nca if cnmt.xml missing. This allow NSP without xml to have Firmware information
- Cart Update and MasterKey for 9.0.0-9.0.1

close #152