### PR TITLE
Fix reading CNMT for XCI files

### DIFF
--- a/Switch Backup Manager/Util.cs
+++ b/Switch Backup Manager/Util.cs
@@ -3293,11 +3293,11 @@ namespace Switch_Backup_Manager
                                 {
                                     using (FileStream fileStream3 = File.OpenRead(cnmt[0]))
                                     {
-                                        byte[] buffer = new byte[32];
+                                        byte[] buffer = new byte[44];
                                         byte[] buffer2 = new byte[56];
                                         CNMT.CNMT_Header[] array7 = new CNMT.CNMT_Header[1];
 
-                                        fileStream3.Read(buffer, 0, 32);
+                                        fileStream3.Read(buffer, 0, 44);
                                         array7[0] = new CNMT.CNMT_Header(buffer);
 
                                         if (array7[0].TitleVersion > version)


### PR DESCRIPTION
This fixes regression bug introduced in 7fb907f51c5c793112b63477b46681d32c118788 where I forgot to change the buffer size for XCI read causing reading CNMT to fail
one of the easiest way to reproduce it by adding a new XCI file and see the game icon shows as not available