### PR TITLE
menuLocalFiles would stay disabled after XCI split

### DIFF
--- a/Switch Backup Manager/Form1.cs
+++ b/Switch Backup Manager/Form1.cs
@@ -4327,6 +4327,7 @@ namespace Switch_Backup_Manager
             toolStripProgressAddingFiles.Visible = false;
             toolStripStatusLabelGame.Text = "";
             toolStripStatusLabelGame.Visible = false;
+            menuLocalFiles.Enabled = true;
 
             MessageBox.Show("Done");
         }


### PR DESCRIPTION
Form1.cs menuLocalFiles doesn't return to enable after XCI split. Had to close and reopen program to get menu to work again.